### PR TITLE
Feat/issue 11 creator dashboard setup

### DIFF
--- a/apps/frontend/app/dashboard/creator/layout.tsx
+++ b/apps/frontend/app/dashboard/creator/layout.tsx
@@ -1,0 +1,20 @@
+import { Sora } from "next/font/google";
+import { DashboardChrome } from "@/components/dashboard/creator/dashboard-chrome";
+
+const sora = Sora({
+  subsets: ["latin"],
+  variable: "--font-sora",
+  weight: ["400", "600", "800"],
+});
+
+export default function CreatorDashboardLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className={sora.variable}>
+      <DashboardChrome>{children}</DashboardChrome>
+    </div>
+  );
+}

--- a/apps/frontend/app/dashboard/creator/page.tsx
+++ b/apps/frontend/app/dashboard/creator/page.tsx
@@ -1,37 +1,59 @@
-import { DashboardShell } from "@/components/dashboard/dashboard-shell";
+import { ClipboardCheck } from "lucide-react";
+import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
+import { StatCard } from "@/components/dashboard/creator/stat-card";
+import { EarningsCard } from "@/components/dashboard/creator/earnings-card";
+import { TrustScoreCard } from "@/components/dashboard/creator/trust-score-card";
+import { ProfileCompletionCard } from "@/components/dashboard/creator/profile-completion-card";
+import { ActiveCampaignsTable } from "@/components/dashboard/creator/active-campaigns-table";
+import { EcosystemIntegrityBanner } from "@/components/dashboard/creator/ecosystem-integrity-banner";
 import {
-  creatorActivity,
-  creatorCampaigns,
-  creatorMetrics,
-  creatorTasks,
-} from "@/components/dashboard/dashboard-data";
+  creatorActiveApplications,
+  creatorActiveCampaigns,
+  creatorEarnings,
+  creatorProfileCompletion,
+  creatorProofsSubmitted,
+  creatorTrustScore,
+} from "@/components/dashboard/creator/creator-dashboard-data";
 
 export default function CreatorDashboardPage() {
   return (
-    <DashboardShell
-      activities={creatorActivity}
-      campaigns={creatorCampaigns}
-      ctaHref="#campaign-workspace"
-      ctaLabel="Complete your creator profile so businesses can match you with funded briefs."
-      eyebrow="Creator dashboard"
-      metrics={creatorMetrics}
-      primaryAction="Complete profile"
-      role="Creator"
-      subtitle="Discover funded campaign briefs, apply with your creator profile, submit proof, and track payout readiness. The current data is mocked until the marketplace and contract reads are connected."
-      tasks={creatorTasks}
-      title="Find campaigns and keep payouts visible."
-    >
-      <div className="rounded-[20px] border border-white/10 bg-[#0b2426] p-5 text-[var(--paper)]">
-        <p className="text-xs font-black uppercase tracking-[0.18em] text-[var(--lime)]">
-          Payout status
-        </p>
-        <h2 className="mt-3 text-lg font-black">Wallet claim flow pending</h2>
-        <p className="mt-2 text-sm leading-relaxed text-[rgba(247,248,242,0.62)]">
-          Creator earnings are represented as product state for now. Once escrow
-          settlement is live, this panel becomes the place to claim approved
-          payouts directly to the connected Stellar wallet.
-        </p>
+    <>
+      <DashboardHeader eyebrow="Welcome back, creator" title="Overview" />
+
+      <div className="grid grid-cols-12 gap-6">
+        <EarningsCard
+          usdApprox={creatorEarnings.usdApprox}
+          xlm={creatorEarnings.xlm}
+        />
+
+        <StatCard
+          align="center"
+          className="col-span-12 sm:col-span-6 lg:col-span-2"
+          label="Active Apps"
+          value={String(creatorActiveApplications)}
+        />
+
+        <TrustScoreCard
+          label={creatorTrustScore.label}
+          max={creatorTrustScore.max}
+          score={creatorTrustScore.score}
+        />
+
+        <StatCard
+          className="col-span-12 sm:col-span-6 lg:col-span-3"
+          delta={`+${creatorProofsSubmitted.deltaThisWeek} this week`}
+          icon={ClipboardCheck}
+          iconTone="muted"
+          label="Proofs Submitted"
+          value={String(creatorProofsSubmitted.total)}
+        />
+
+        <ProfileCompletionCard steps={creatorProfileCompletion} />
+
+        <ActiveCampaignsTable campaigns={creatorActiveCampaigns} />
       </div>
-    </DashboardShell>
+
+      <EcosystemIntegrityBanner />
+    </>
   );
 }

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -16,6 +16,19 @@
   --shadow: 0 30px 80px rgba(0, 0, 0, 0.28);
 }
 
+.creator-dashboard-theme {
+  --dash-bg: #121212;
+  --dash-surface: #1a1a1a;
+  --dash-border: #262626;
+  --dash-heading: #ffffff;
+  --dash-body: #e5e2e1;
+  --dash-muted: #c5c9ae;
+  --dash-accent: #add500;
+  --dash-on-accent: #293500;
+  --dash-accent-strong: #c8f232;
+  --dash-on-accent-strong: #576c00;
+}
+
 @theme inline {
   --color-background: var(--bg);
   --color-foreground: var(--paper);

--- a/apps/frontend/components/dashboard/creator/active-campaigns-table.tsx
+++ b/apps/frontend/components/dashboard/creator/active-campaigns-table.tsx
@@ -1,0 +1,145 @@
+import Link from "next/link";
+import { Inbox, MoreVertical } from "lucide-react";
+import type { CreatorCampaign } from "./creator-dashboard-data";
+
+const statusStyles: Record<CreatorCampaign["status"], string> = {
+  active: "border-[var(--dash-accent)] text-[var(--dash-accent)]",
+  review: "border-[var(--dash-muted)] text-[var(--dash-muted)]",
+};
+
+const statusLabels: Record<CreatorCampaign["status"], string> = {
+  active: "Active",
+  review: "Review",
+};
+
+export function ActiveCampaignsTable({
+  campaigns,
+}: {
+  campaigns: CreatorCampaign[];
+}) {
+  return (
+    <article className="col-span-12 min-w-0 overflow-hidden border border-[var(--dash-border)] bg-[var(--dash-surface)] p-6 lg:col-span-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-heading)]">
+          Active Campaigns
+        </h2>
+        <Link
+          href="/dashboard/creator/campaigns"
+          className="rounded text-xs font-bold text-[var(--dash-accent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] hover:underline"
+        >
+          VIEW ALL
+        </Link>
+      </div>
+
+      {campaigns.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-12 text-center">
+          <Inbox className="size-10 text-[var(--dash-muted)]" aria-hidden="true" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-[var(--dash-heading)]">
+              No active campaigns yet
+            </p>
+            <p className="text-xs text-[var(--dash-muted)]">
+              Apply to a funded brief to see it tracked here.
+            </p>
+          </div>
+          <Link
+            href="/dashboard/creator/campaigns"
+            className="rounded bg-[var(--dash-accent)] px-4 py-2 text-sm font-bold text-[var(--dash-on-accent)] hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+          >
+            Browse campaigns
+          </Link>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-left">
+            <thead className="border-b border-[var(--dash-border)]">
+              <tr>
+                <th className="pb-4 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+                  Campaign
+                </th>
+                <th className="pb-4 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+                  Status
+                </th>
+                <th className="pb-4 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+                  Progress
+                </th>
+                <th className="pb-4 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+                  Earnings
+                </th>
+                <th className="pb-4">
+                  <span className="sr-only">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--dash-border)]">
+              {campaigns.map((campaign) => {
+                const Icon = campaign.icon;
+
+                return (
+                  <tr key={campaign.id}>
+                    <td className="py-4">
+                      <div className="flex items-center gap-3">
+                        <div className="flex size-8 shrink-0 items-center justify-center rounded border border-[var(--dash-border)] bg-[#262626]">
+                          <Icon className="size-[18px] text-[var(--dash-body)]" aria-hidden="true" />
+                        </div>
+                        <div>
+                          <p className="font-medium text-[var(--dash-heading)]">
+                            {campaign.name}
+                          </p>
+                          <p className="text-xs text-[var(--dash-muted)]">
+                            {campaign.category} • {campaign.tier}
+                          </p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="py-4">
+                      <span
+                        className={`rounded border px-2 py-0.5 text-[10px] font-bold tracking-widest ${statusStyles[campaign.status]}`}
+                      >
+                        {statusLabels[campaign.status].toUpperCase()}
+                      </span>
+                    </td>
+                    <td className="py-4">
+                      <div className="flex items-center gap-3">
+                        <div
+                          className="h-1 max-w-[80px] flex-grow rounded-full bg-[var(--dash-border)]"
+                          role="progressbar"
+                          aria-valuenow={campaign.progress}
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-label={`${campaign.name} progress`}
+                        >
+                          <div
+                            className="h-full rounded-full bg-[var(--dash-heading)]"
+                            style={{ width: `${campaign.progress}%` }}
+                          />
+                        </div>
+                        <span className="font-mono text-xs text-[var(--dash-body)]">
+                          {campaign.progress}%
+                        </span>
+                      </div>
+                    </td>
+                    <td className="py-4 font-medium text-[var(--dash-heading)]">
+                      {campaign.earnings}
+                    </td>
+                    <td className="py-4 text-right">
+                      <button
+                        type="button"
+                        disabled
+                        title="More actions (coming soon)"
+                        aria-label={`More actions for ${campaign.name} (coming soon)`}
+                        className="inline-flex size-10 items-center justify-center rounded text-[var(--dash-muted)] disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <MoreVertical className="size-[18px]" aria-hidden="true" />
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/creator-dashboard-data.ts
+++ b/apps/frontend/components/dashboard/creator/creator-dashboard-data.ts
@@ -1,0 +1,82 @@
+import {
+  Gamepad2,
+  Smartphone,
+  ShoppingBag,
+  type LucideIcon,
+} from "lucide-react";
+
+export type ProfileCompletionStep = {
+  complete: boolean;
+  label: string;
+};
+
+export type CreatorCampaignStatus = "active" | "review";
+
+export type CreatorCampaign = {
+  category: string;
+  earnings: string;
+  icon: LucideIcon;
+  id: string;
+  name: string;
+  progress: number;
+  status: CreatorCampaignStatus;
+  tier: string;
+};
+
+export const creatorEarnings = {
+  usdApprox: "284.10",
+  xlm: "2,480",
+};
+
+export const creatorActiveApplications = 12;
+
+export const creatorTrustScore = {
+  label: "RELIABILITY",
+  max: 100,
+  score: 94,
+};
+
+export const creatorProofsSubmitted = {
+  deltaThisWeek: 8,
+  total: 142,
+};
+
+export const creatorProfileCompletion: ProfileCompletionStep[] = [
+  { complete: true, label: "Connect Stellar Wallet" },
+  { complete: true, label: "Identity Verification (KYC)" },
+  { complete: false, label: "Link Social Channels" },
+  { complete: false, label: "Define Ad Rate Card" },
+];
+
+export const creatorActiveCampaigns: CreatorCampaign[] = [
+  {
+    category: "Utility",
+    earnings: "450 XLM",
+    icon: Smartphone,
+    id: "lumina-vpn-pro",
+    name: "Lumina VPN Pro",
+    progress: 75,
+    status: "active",
+    tier: "Tier 1",
+  },
+  {
+    category: "Gaming",
+    earnings: "1,200 XLM",
+    icon: Gamepad2,
+    id: "cyberracer-2077",
+    name: "CyberRacer 2077",
+    progress: 100,
+    status: "review",
+    tier: "Tier 2",
+  },
+  {
+    category: "Finance",
+    earnings: "830 XLM",
+    icon: ShoppingBag,
+    id: "ecocart-checkout",
+    name: "EcoCart Checkout",
+    progress: 32,
+    status: "active",
+    tier: "Tier 1",
+  },
+];

--- a/apps/frontend/components/dashboard/creator/dashboard-chrome.tsx
+++ b/apps/frontend/components/dashboard/creator/dashboard-chrome.tsx
@@ -34,7 +34,7 @@ export function DashboardChrome({ children }: { children: ReactNode }) {
   }, [mobileNavOpen]);
 
   return (
-    <div className="creator-dashboard-theme min-h-screen bg-[var(--dash-bg)] text-[var(--dash-body)]">
+    <div className="creator-dashboard-theme min-h-screen overflow-x-hidden bg-[var(--dash-bg)] text-[var(--dash-body)]">
       <aside className="fixed top-0 left-0 hidden h-screen w-64 border-r border-[var(--dash-border)] bg-[var(--dash-surface)] lg:flex">
         <SidebarNav />
       </aside>

--- a/apps/frontend/components/dashboard/creator/dashboard-chrome.tsx
+++ b/apps/frontend/components/dashboard/creator/dashboard-chrome.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { X } from "lucide-react";
+import { SidebarNav } from "./sidebar-nav";
+import { DashboardFooter } from "./dashboard-footer";
+import { MobileNavProvider } from "./mobile-nav-context";
+
+export function DashboardChrome({ children }: { children: ReactNode }) {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const mainRef = useRef<HTMLElement>(null);
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  const closeMobileNav = () => {
+    setMobileNavOpen(false);
+    mainRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (!mobileNavOpen) {
+      return;
+    }
+
+    drawerRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeMobileNav();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [mobileNavOpen]);
+
+  return (
+    <div className="creator-dashboard-theme min-h-screen bg-[var(--dash-bg)] text-[var(--dash-body)]">
+      <aside className="fixed top-0 left-0 hidden h-screen w-64 border-r border-[var(--dash-border)] bg-[var(--dash-surface)] lg:flex">
+        <SidebarNav />
+      </aside>
+
+      {mobileNavOpen ? (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          <button
+            type="button"
+            aria-label="Close dashboard navigation"
+            onClick={closeMobileNav}
+            className="absolute inset-0 bg-black/60"
+          />
+          <div
+            ref={drawerRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Dashboard navigation"
+            tabIndex={-1}
+            className="absolute top-0 left-0 flex h-full w-64 max-w-[80vw] flex-col border-r border-[var(--dash-border)] bg-[var(--dash-surface)] focus:outline-none"
+          >
+            <button
+              type="button"
+              onClick={closeMobileNav}
+              aria-label="Close dashboard navigation"
+              className="absolute top-4 right-4 flex size-9 items-center justify-center rounded-lg text-[var(--dash-muted)] hover:bg-[var(--dash-border)] hover:text-[var(--dash-heading)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+            >
+              <X className="size-5" aria-hidden="true" />
+            </button>
+            <SidebarNav onNavigate={closeMobileNav} />
+          </div>
+        </div>
+      ) : null}
+
+      <MobileNavProvider openMobileNav={() => setMobileNavOpen(true)}>
+        <main
+          ref={mainRef}
+          tabIndex={-1}
+          className="mx-auto max-w-[1280px] px-4 py-6 outline-none sm:px-6 lg:ml-64 lg:px-8 lg:py-8"
+        >
+          {children}
+
+          <DashboardFooter />
+        </main>
+      </MobileNavProvider>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/dashboard-footer.tsx
+++ b/apps/frontend/components/dashboard/creator/dashboard-footer.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+
+const resourceLinks = [
+  { href: "/docs", label: "Documentation" },
+  { href: "/brand", label: "Brand Kit" },
+  { href: "/docs/stellar-guide", label: "Stellar Guide" },
+];
+
+const communityLinks = [
+  { href: "https://discord.com", label: "Discord" },
+  { href: "https://x.com", label: "Twitter/X" },
+  { href: "/forum", label: "Forum" },
+];
+
+export function DashboardFooter() {
+  return (
+    <footer className="mt-20 flex flex-col gap-8 border-t border-[var(--dash-border)] pb-12 pt-12 md:flex-row md:items-start md:justify-between">
+      <div className="max-w-xs">
+        <p className="mb-2 text-lg font-bold text-[var(--dash-heading)]">
+          AdsBazaar
+        </p>
+        <p className="text-sm leading-relaxed text-[var(--dash-muted)]">
+          The authority for creator-led decentralized advertising. Built for
+          transparency, speed, and trust.
+        </p>
+      </div>
+
+      <div className="flex gap-16">
+        <div>
+          <h2 className="mb-4 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-heading)]">
+            Resources
+          </h2>
+          <ul className="space-y-2 text-sm text-[var(--dash-muted)]">
+            {resourceLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] hover:text-[var(--dash-accent)]"
+                >
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <h2 className="mb-4 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-heading)]">
+            Community
+          </h2>
+          <ul className="space-y-2 text-sm text-[var(--dash-muted)]">
+            {communityLinks.map((link) => (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className="rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] hover:text-[var(--dash-accent)]"
+                >
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/dashboard-header.tsx
+++ b/apps/frontend/components/dashboard/creator/dashboard-header.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Menu, Wallet } from "lucide-react";
+import { useMobileNav } from "./mobile-nav-context";
+
+function WalletChip({ address = "G...k82X" }: { address?: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded border border-[var(--dash-border)] bg-[var(--dash-surface)] px-4 py-2">
+      <Wallet className="size-[18px] text-[var(--dash-accent)]" aria-hidden="true" />
+      <span className="text-[15px] font-medium text-[var(--dash-body)]">
+        {address}
+      </span>
+    </div>
+  );
+}
+
+export function DashboardHeader({
+  eyebrow,
+  title,
+}: {
+  eyebrow: string;
+  title: string;
+}) {
+  const { openMobileNav } = useMobileNav();
+
+  return (
+    <div className="mb-8 lg:mb-12">
+      <div className="mb-4 flex items-center justify-between gap-4 lg:hidden">
+        <button
+          type="button"
+          onClick={openMobileNav}
+          aria-label="Open dashboard navigation"
+          className="-ml-2 flex size-11 items-center justify-center rounded-lg text-[var(--dash-body)] transition-colors hover:bg-[var(--dash-surface)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+        >
+          <Menu className="size-6" aria-hidden="true" />
+        </button>
+        <WalletChip />
+      </div>
+
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="mb-1 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-accent)]">
+            {eyebrow}
+          </p>
+          <h1 className="font-[family-name:var(--font-sora)] text-[32px] font-semibold leading-[1.2] tracking-[-0.02em] text-[var(--dash-heading)]">
+            {title}
+          </h1>
+        </div>
+        <div className="hidden lg:block">
+          <WalletChip />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/earnings-card.tsx
+++ b/apps/frontend/components/dashboard/creator/earnings-card.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle2, Loader2, Wallet, Zap } from "lucide-react";
+
+type ClaimStatus = "idle" | "loading" | "success";
+
+export function EarningsCard({
+  usdApprox,
+  xlm,
+}: {
+  usdApprox: string;
+  xlm: string;
+}) {
+  const [status, setStatus] = useState<ClaimStatus>("idle");
+
+  const handleClaim = () => {
+    if (status !== "idle") {
+      return;
+    }
+
+    setStatus("loading");
+    window.setTimeout(() => setStatus("success"), 1500);
+  };
+
+  return (
+    <article className="col-span-12 flex flex-col justify-between border border-[var(--dash-border)] bg-[var(--dash-surface)] p-6 lg:col-span-4">
+      <div>
+        <div className="mb-4 flex items-start justify-between">
+          <span className="text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+            Earnings Available
+          </span>
+          <Wallet className="size-5 text-[var(--dash-accent)]" aria-hidden="true" />
+        </div>
+        <p className="font-[family-name:var(--font-sora)] text-[40px] font-semibold leading-none text-[var(--dash-heading)]">
+          {xlm} XLM
+        </p>
+        <p className="mt-2 text-sm text-[var(--dash-muted)]">
+          ≈ ${usdApprox} USD
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleClaim}
+        disabled={status !== "idle"}
+        aria-busy={status === "loading"}
+        className={`mt-6 flex min-h-11 w-full items-center justify-center gap-2 rounded py-3 font-bold transition-opacity focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] disabled:cursor-not-allowed ${
+          status === "success"
+            ? "bg-[var(--dash-border)] text-[var(--dash-accent)]"
+            : "bg-[var(--dash-accent)] text-[var(--dash-on-accent)] hover:opacity-90 disabled:opacity-80"
+        }`}
+      >
+        {status === "idle" ? (
+          <>
+            <Zap className="size-5" aria-hidden="true" />
+            Claim Payout
+          </>
+        ) : status === "loading" ? (
+          <>
+            <Loader2 className="size-5 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+            Processing payout…
+          </>
+        ) : (
+          <>
+            <CheckCircle2 className="size-5" aria-hidden="true" />
+            Payout initiated
+          </>
+        )}
+      </button>
+    </article>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/ecosystem-integrity-banner.tsx
+++ b/apps/frontend/components/dashboard/creator/ecosystem-integrity-banner.tsx
@@ -1,0 +1,16 @@
+export function EcosystemIntegrityBanner() {
+  return (
+    <section className="mt-12 lg:mt-20">
+      <div className="relative flex h-80 w-full flex-col items-center justify-center rounded-xl border border-[var(--dash-border)] bg-[var(--dash-surface)] px-6 text-center sm:px-12">
+        <h2 className="font-[family-name:var(--font-sora)] mb-4 text-2xl font-semibold text-[var(--dash-heading)]">
+          Ecosystem Integrity
+        </h2>
+        <p className="max-w-xl text-base leading-relaxed text-[var(--dash-muted)]">
+          Our decentralized proof system ensures that every interaction is
+          verifiable on the Stellar network, protecting your reputation and
+          ensuring instant payouts.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/mobile-nav-context.tsx
+++ b/apps/frontend/components/dashboard/creator/mobile-nav-context.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+type MobileNavContextValue = {
+  openMobileNav: () => void;
+};
+
+const MobileNavContext = createContext<MobileNavContextValue | null>(null);
+
+export function MobileNavProvider({
+  children,
+  openMobileNav,
+}: {
+  children: ReactNode;
+  openMobileNav: () => void;
+}) {
+  return (
+    <MobileNavContext.Provider value={{ openMobileNav }}>
+      {children}
+    </MobileNavContext.Provider>
+  );
+}
+
+export function useMobileNav() {
+  const context = useContext(MobileNavContext);
+
+  if (!context) {
+    throw new Error("useMobileNav must be used within a MobileNavProvider");
+  }
+
+  return context;
+}

--- a/apps/frontend/components/dashboard/creator/profile-completion-card.tsx
+++ b/apps/frontend/components/dashboard/creator/profile-completion-card.tsx
@@ -1,0 +1,39 @@
+import { CheckCircle2, Circle } from "lucide-react";
+import type { ProfileCompletionStep } from "./creator-dashboard-data";
+
+export function ProfileCompletionCard({
+  steps,
+}: {
+  steps: ProfileCompletionStep[];
+}) {
+  return (
+    <article className="col-span-12 border border-[var(--dash-border)] bg-[#262626] p-6 lg:col-span-4">
+      <h2 className="mb-6 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-heading)]">
+        Profile Completion
+      </h2>
+      <ul className="space-y-4">
+        {steps.map((step) => (
+          <li
+            key={step.label}
+            className={`flex items-center gap-3 ${step.complete ? "" : "opacity-50"}`}
+          >
+            {step.complete ? (
+              <CheckCircle2
+                className="size-5 shrink-0 text-[var(--dash-accent)]"
+                aria-hidden="true"
+              />
+            ) : (
+              <Circle
+                className="size-5 shrink-0 text-[var(--dash-muted)]"
+                aria-hidden="true"
+              />
+            )}
+            <span className="text-base text-[var(--dash-body)]">
+              {step.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/sidebar-nav.tsx
+++ b/apps/frontend/components/dashboard/creator/sidebar-nav.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  Archive,
+  BarChart3,
+  HelpCircle,
+  LayoutDashboard,
+  LogOut,
+  Megaphone,
+  Settings,
+  Wallet,
+  type LucideIcon,
+} from "lucide-react";
+
+type NavItem = {
+  href: string;
+  icon: LucideIcon;
+  label: string;
+};
+
+const navItems: NavItem[] = [
+  { href: "/dashboard/creator", icon: LayoutDashboard, label: "Dashboard" },
+  { href: "/dashboard/creator/campaigns", icon: Megaphone, label: "Campaigns" },
+  { href: "/dashboard/creator/inventory", icon: Archive, label: "Inventory" },
+  { href: "/dashboard/creator/analytics", icon: BarChart3, label: "Analytics" },
+  { href: "/dashboard/creator/payouts", icon: Wallet, label: "Payouts" },
+  { href: "/dashboard/creator/settings", icon: Settings, label: "Settings" },
+];
+
+function isActiveHref(pathname: string, href: string) {
+  if (href === "/dashboard/creator") {
+    return pathname === href;
+  }
+
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  return (
+    <div className="flex h-full flex-col gap-4 px-4 py-6">
+      <div className="mb-4 px-2">
+        <h1 className="text-[20px] font-bold tracking-tight text-[var(--dash-heading)]">
+          AdsBazaar Business
+        </h1>
+        <p className="text-[12px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)] opacity-70">
+          Creator Economy Hub
+        </p>
+      </div>
+
+      <nav className="flex flex-grow flex-col gap-1" aria-label="Dashboard navigation">
+        {navItems.map((item) => {
+          const active = isActiveHref(pathname, item.href);
+          const Icon = item.icon;
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavigate}
+              aria-current={active ? "page" : undefined}
+              className={`flex min-h-11 items-center gap-3 rounded-lg px-3 py-2 text-[15px] font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] ${
+                active
+                  ? "bg-[var(--dash-accent-strong)] font-bold text-[var(--dash-on-accent-strong)]"
+                  : "text-[var(--dash-muted)] hover:bg-[var(--dash-border)] hover:text-[var(--dash-heading)]"
+              }`}
+            >
+              <Icon className="size-5" aria-hidden="true" />
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+
+      <Link
+        href="/dashboard/creator/campaigns/new"
+        onClick={onNavigate}
+        className="mt-4 flex min-h-11 items-center justify-center rounded-lg bg-[var(--dash-accent-strong)] py-3 text-center font-bold text-[var(--dash-on-accent-strong)] transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+      >
+        New Campaign
+      </Link>
+
+      <div className="mt-auto flex flex-col gap-1">
+        <Link
+          href="/help"
+          onClick={onNavigate}
+          className="flex min-h-11 items-center gap-3 rounded-lg px-3 py-2 text-[15px] font-medium text-[var(--dash-muted)] transition-colors hover:bg-[var(--dash-border)] hover:text-[var(--dash-heading)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+        >
+          <HelpCircle className="size-5" aria-hidden="true" />
+          <span>Help Center</span>
+        </Link>
+        <button
+          type="button"
+          onClick={() => {
+            onNavigate?.();
+            router.push("/");
+          }}
+          className="flex min-h-11 items-center gap-3 rounded-lg px-3 py-2 text-left text-[15px] font-medium text-[var(--dash-muted)] transition-colors hover:bg-[var(--dash-border)] hover:text-[var(--dash-heading)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+        >
+          <LogOut className="size-5" aria-hidden="true" />
+          <span>Logout</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/stat-card.tsx
+++ b/apps/frontend/components/dashboard/creator/stat-card.tsx
@@ -1,0 +1,61 @@
+import type { LucideIcon } from "lucide-react";
+
+type StatCardProps = {
+  align?: "center" | "start";
+  className?: string;
+  delta?: string;
+  icon?: LucideIcon;
+  iconTone?: "accent" | "muted";
+  label: string;
+  value: string;
+};
+
+export function StatCard({
+  align = "start",
+  className = "",
+  delta,
+  icon: Icon,
+  iconTone = "accent",
+  label,
+  value,
+}: StatCardProps) {
+  const isCenter = align === "center";
+
+  return (
+    <article
+      className={`border border-[var(--dash-border)] bg-[var(--dash-surface)] p-6 ${
+        isCenter ? "flex flex-col items-center justify-center text-center" : ""
+      } ${className}`}
+    >
+      {Icon ? (
+        <div className="flex items-start justify-between gap-2">
+          <span className="text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+            {label}
+          </span>
+          <Icon
+            className={`size-5 ${
+              iconTone === "accent" ? "text-[var(--dash-accent)]" : "text-[var(--dash-muted)]"
+            }`}
+            aria-hidden="true"
+          />
+        </div>
+      ) : (
+        <span className="block text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+          {label}
+        </span>
+      )}
+
+      <p
+        className={`font-[family-name:var(--font-sora)] text-[24px] font-semibold text-[var(--dash-heading)] ${
+          isCenter ? "mt-2" : "mt-4"
+        }`}
+      >
+        {value}
+      </p>
+
+      {delta ? (
+        <p className="mt-1 text-sm text-[var(--dash-muted)]">{delta}</p>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/trust-score-card.tsx
+++ b/apps/frontend/components/dashboard/creator/trust-score-card.tsx
@@ -1,0 +1,47 @@
+import { BadgeCheck } from "lucide-react";
+
+export function TrustScoreCard({
+  label,
+  max,
+  score,
+}: {
+  label: string;
+  max: number;
+  score: number;
+}) {
+  const percent = Math.round((score / max) * 100);
+
+  return (
+    <article className="col-span-12 border border-[var(--dash-border)] bg-[var(--dash-surface)] p-6 sm:col-span-6 lg:col-span-3">
+      <div className="mb-4 flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+          Trust Score
+        </span>
+        <BadgeCheck className="size-5 text-[var(--dash-accent)]" aria-hidden="true" />
+      </div>
+
+      <div
+        className="mb-2 h-2 w-full overflow-hidden rounded-full bg-[var(--dash-border)]"
+        role="progressbar"
+        aria-valuenow={score}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-label="Trust score"
+      >
+        <div
+          className="h-full rounded-full bg-[var(--dash-accent)]"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+
+      <div className="flex justify-between">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+          {label}
+        </span>
+        <span className="text-[18px] font-semibold text-[var(--dash-heading)]">
+          {score}/{max}
+        </span>
+      </div>
+    </article>
+  );
+}

--- a/brand.md
+++ b/brand.md
@@ -1,0 +1,15 @@
+# Brand — AdsBazaar
+
+_Status: deferred_
+
+The user provided an explicit, pixel-level color/typography spec (dark Material-You-inspired palette: `#121212` background, `#1A1A1A` surface, `#add500`/`#c8f232` lime-green accent, Sora + Geist fonts) directly in the GitHub issue for the Creator Dashboard. That spec is the source of truth for this dashboard's visual design — running `brand-design` would generate an unrelated palette and conflict with it.
+
+The marketing site and other dashboards (e.g. `/dashboard/business`) continue to use the existing `--lime`/`--paper`/`--ink` tokens defined in `app/globals.css`. The creator dashboard introduces its own scoped `--dash-*` tokens for its dark theme — see `app/globals.css`.
+
+To set up a project-wide brand palette at any time, run:
+
+    /brand-design
+
+or say: "pick brand colors"
+
+_Deferred at: 2026-06-16_


### PR DESCRIPTION
## Summary

Implements the Creator Dashboard Overview page (`/dashboard/creator`), matching the dark, Material-You-inspired mockup from the issue, broken into focused, reusable components and a proper Next.js layout instead of one monolithic page.

### Layout (reusable by future creator pages)
- `app/dashboard/creator/layout.tsx` — wraps every `/dashboard/creator/*` route, loads the Sora display font, and renders `DashboardChrome`.
- `DashboardChrome` — owns the sidebar/drawer state and the `<main>` content wrapper + footer. Desktop (`lg:` and up) gets a fixed 256px sidebar rail; below `lg`, the sidebar collapses into an off-canvas drawer (backdrop click, Escape key, and focus-return all handled).
- `SidebarNav` — nav links (Dashboard, Campaigns, Inventory, Analytics, Payouts, Settings), active-route highlighting via `usePathname`, "New Campaign" CTA, Help Center / Logout. Shared between the desktop rail and mobile drawer.
- `DashboardHeader` + `MobileNavProvider` (context) — per-page eyebrow/title header that shares its row with the wallet chip (matches the mockup) and exposes the mobile menu trigger via context, since the drawer toggle is owned by the layout but the trigger button lives in page-level header markup.
- `DashboardFooter` — resources/community links, rendered once in the layout.

### Page content (`app/dashboard/creator/page.tsx`)
- `EarningsCard` — XLM balance + USD estimate; Claim Payout button has real idle/loading/success states (no dead click).
- `StatCard` — generic metric card, reused for both "Active Apps" (centered, no icon) and "Proofs Submitted" (icon + delta).
- `TrustScoreCard` — reliability progress bar.
- `ProfileCompletionCard` — onboarding checklist with complete/incomplete states.
- `ActiveCampaignsTable` — campaign rows with status badge, progress bar, earnings; includes a real empty state ("No active campaigns yet" + browse CTA) for creators with nothing active yet, and a horizontally-scrollable wrapper so the table degrades gracefully on narrow screens instead of being hidden or breaking layout.
- `EcosystemIntegrityBanner` — static trust-signal banner.
- Mock data lives in `creator-dashboard-data.ts`, consistent with the existing convention (business/creator dashboards are mocked until contract reads are wired up).

### Styling
- New `--dash-*` CSS custom properties scoped to a `.creator-dashboard-theme` class in `globals.css` (background, surface, border, text, and two accent/on-accent pairs lifted from the mockup's Material color tokens). Scoped on purpose so the marketing site and `/dashboard/business` (which still use the existing `--lime`/`--paper`/`--ink` tokens) are untouched.
- Added `lucide-react` for icons (project had no icon library yet).
- `brand.md` added as `deferred` — the issue supplied an explicit pixel-level color/font spec for this dashboard, so the project-wide `brand-design` flow was intentionally skipped rather than generating a conflicting palette.

### Accessibility
- All interactive elements are real `<button>`/`<a>` with visible focus rings, 40px+ touch targets, and `aria-label`s on icon-only controls.
- Drawer is a proper `role="dialog" aria-modal="true"` with Escape-to-close and focus return to `<main>`.
- Progress bars use `role="progressbar"` with `aria-valuenow/min/max`.
- The campaign row "more actions" button is rendered `disabled` with a `(coming soon)` label rather than being a non-functional dead click, since no row-action menu was specified in scope.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] `next lint` — currently broken repo-wide on this Next 16 version (`next lint` was removed upstream in favor of other tooling); pre-existing, unrelated to this PR
- [x] Verified at 375px / 768px / 1280px using Chrome DevTools Protocol device emulation — confirmed zero horizontal page overflow at every width (`document.documentElement.scrollWidth === window.innerWidth`), wallet chip shares the header row with the page title as in the mockup, sidebar correctly collapses into the accessible drawer below `lg`
- [x] Confirmed `/dashboard/business` and `/` (landing page) render unaffected (200, no visual/style regressions) since the new theme tokens are scoped

Closes #11
