### PR TITLE
fix: replaced sidebar content

### DIFF
--- a/apps/frontend/components/dashboard/creator/sidebar-nav.tsx
+++ b/apps/frontend/components/dashboard/creator/sidebar-nav.tsx
@@ -45,7 +45,7 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
     <div className="flex h-full flex-col gap-4 px-4 py-6">
       <div className="mb-4 px-2">
         <h1 className="text-[20px] font-bold tracking-tight text-[var(--dash-heading)]">
-          AdsBazaar Business
+          AdsBazaar Creator
         </h1>
         <p className="text-[12px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)] opacity-70">
           Creator Economy Hub


### PR DESCRIPTION
## Fix creator dashboard sidebar heading

### Description
The creator dashboard sidebar incorrectly displayed "AdsBazaar Business" as its heading, which was confusing for creators. This was likely due to the sidebar being copy-pasted from the business dashboard without updating the title.

resolves #24 

### Changes
- Update creator sidebar heading from "AdsBazaar Business" to "AdsBazaar Creator"
- Subtitle "Creator Economy Hub" remains unchanged
- Business dashboard sidebar unaffected

### Impact
Fixes the branding inconsistency and improves clarity for creator users.

### Files Changed
- `apps/frontend/components/dashboard/creator/sidebar-nav.tsx`
