### PR TITLE
feat(dashboard): add creator analytics and settings stub pages

### DIFF
--- a/apps/frontend/app/dashboard/creator/analytics/page.tsx
+++ b/apps/frontend/app/dashboard/creator/analytics/page.tsx
@@ -5,11 +5,11 @@ export default function CreatorAnalyticsPage() {
     <>
       <DashboardHeader eyebrow="Performance insights" title="Analytics" />
 
-      <div className="flex flex-col items-center justify-center gap-2 border border-(--dash-border) bg-(--dash-surface) px-6 py-20 text-center">
-        <p className="text-sm font-medium text-(--dash-heading)">
+      <div className="flex flex-col items-center justify-center gap-2 border border-[var(--dash-border)] bg-[var(--dash-surface)] px-6 py-20 text-center">
+        <p className="text-sm font-medium text-[var(--dash-heading)]">
           This page is under construction.
         </p>
-        <p className="max-w-md text-sm text-(--dash-muted)">
+        <p className="max-w-md text-sm text-[var(--dash-muted)]">
           Creator analytics and performance tracking coming soon.
         </p>
       </div>

--- a/apps/frontend/app/dashboard/creator/analytics/page.tsx
+++ b/apps/frontend/app/dashboard/creator/analytics/page.tsx
@@ -1,0 +1,18 @@
+import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
+
+export default function CreatorAnalyticsPage() {
+  return (
+    <>
+      <DashboardHeader eyebrow="Performance insights" title="Analytics" />
+
+      <div className="flex flex-col items-center justify-center gap-2 border border-(--dash-border) bg-(--dash-surface) px-6 py-20 text-center">
+        <p className="text-sm font-medium text-(--dash-heading)">
+          This page is under construction.
+        </p>
+        <p className="max-w-md text-sm text-(--dash-muted)">
+          Creator analytics and performance tracking coming soon.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/apps/frontend/app/dashboard/creator/settings/page.tsx
+++ b/apps/frontend/app/dashboard/creator/settings/page.tsx
@@ -1,0 +1,18 @@
+import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
+
+export default function CreatorSettingsPage() {
+  return (
+    <>
+      <DashboardHeader eyebrow="Account preferences" title="Settings" />
+
+      <div className="flex flex-col items-center justify-center gap-2 border border-(--dash-border) bg-(--dash-surface) px-6 py-20 text-center">
+        <p className="text-sm font-medium text-(--dash-heading)">
+          This page is under construction.
+        </p>
+        <p className="max-w-md text-sm text-(--dash-muted)">
+          Profile settings and notification preferences coming soon.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/apps/frontend/app/dashboard/creator/settings/page.tsx
+++ b/apps/frontend/app/dashboard/creator/settings/page.tsx
@@ -5,11 +5,11 @@ export default function CreatorSettingsPage() {
     <>
       <DashboardHeader eyebrow="Account preferences" title="Settings" />
 
-      <div className="flex flex-col items-center justify-center gap-2 border border-(--dash-border) bg-(--dash-surface) px-6 py-20 text-center">
-        <p className="text-sm font-medium text-(--dash-heading)">
+      <div className="flex flex-col items-center justify-center gap-2 border border-[var(--dash-border)] bg-[var(--dash-surface)] px-6 py-20 text-center">
+        <p className="text-sm font-medium text-[var(--dash-heading)]">
           This page is under construction.
         </p>
-        <p className="max-w-md text-sm text-(--dash-muted)">
+        <p className="max-w-md text-sm text-[var(--dash-muted)]">
           Profile settings and notification preferences coming soon.
         </p>
       </div>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "apps/*"
   - "packages/*"
+allowBuilds:
+  sharp: set this to true or false
+  unrs-resolver: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,3 @@
 packages:
   - "apps/*"
   - "packages/*"
-allowBuilds:
-  sharp: set this to true or false
-  unrs-resolver: set this to true or false


### PR DESCRIPTION
- Add app/dashboard/creator/analytics/page.tsx stub
- Add app/dashboard/creator/settings/page.tsx stub
- Reuse existing DashboardHeader component for consistent header treatment
- Render under-construction placeholder using --dash-* design tokens only
- No sidebar/layout wrapper added — inherited from app/dashboard/creator/layout.tsx
- All 6 creator sidebar links now resolve to real pages, no more 404s

Closes #27