### PR TITLE
feat(onboarding): implement multi-step onboarding flow — role selection, registration & completion

### DIFF
--- a/apps/frontend/app/onboarding/business/page.tsx
+++ b/apps/frontend/app/onboarding/business/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { StepIndicator } from "@/components/onboarding/step-indicator";
+import { BusinessForm } from "@/components/onboarding/business-form";
+
+const STORAGE_KEY = "adsbazaar_onboarding";
+
+function loadDraft() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed.businessForm) return parsed.businessForm;
+    }
+  } catch {}
+  return {
+    name: "",
+    industry: "",
+    country: "",
+    email: "",
+    website: "",
+    description: "",
+  };
+}
+
+function saveDraft(data: Record<string, string>) {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    const existing = raw ? JSON.parse(raw) : {};
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        ...existing,
+        step: 2,
+        role: "business",
+        businessForm: data,
+      }),
+    );
+  } catch {}
+}
+
+export default function BusinessRegistrationPage() {
+  const router = useRouter();
+  const [data, setData] = useState(loadDraft);
+
+  useEffect(() => {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed.businessForm) setData(parsed.businessForm);
+      } catch {}
+    }
+  }, []);
+
+  const handleChange = (next: typeof data) => {
+    setData(next);
+    saveDraft(next);
+  };
+
+  return (
+    <div className="w-full max-w-[800px]">
+      <StepIndicator
+        variant="bars"
+        totalSteps={3}
+        currentStep={2}
+        label="Profile Setup"
+      />
+      <div className="bg-[var(--db-surface)] border border-[var(--db-outline-variant)] rounded-[8px] overflow-hidden">
+        <BusinessForm
+          data={data}
+          onChange={handleChange}
+          onSubmit={() => router.push("/onboarding/complete/business")}
+          onBack={() => router.push("/onboarding/role")}
+        />
+      </div>
+      <p className="font-geist text-[13px] text-[var(--db-on-surface-variant)] text-center mt-6 max-w-[540px] mx-auto">
+        By continuing, you agree to our{" "}
+        <span className="text-[var(--db-on-surface)]  hover:underline cursor-pointer">
+          Service Terms
+        </span>
+        . Your information is encrypted and stored on the Stellar network.
+      </p>
+    </div>
+  );
+}

--- a/apps/frontend/app/onboarding/complete/business/page.tsx
+++ b/apps/frontend/app/onboarding/complete/business/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import {
+  ArrowRight,
+  CircleCheck,
+  ShieldCheck,
+  Briefcase,
+  Wallet,
+  Lock,
+} from "lucide-react";
+import { getAddress, isAllowed, isConnected } from "@stellar/freighter-api";
+import { StepIndicator } from "@/components/onboarding/step-indicator";
+
+const STORAGE_KEY = "adsbazaar_onboarding";
+
+export default function BusinessCompletionPage() {
+  const router = useRouter();
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } catch {}
+
+    const restore = async () => {
+      try {
+        const connected = await isConnected();
+        if (connected.error || !connected.isConnected) return;
+        const allowed = await isAllowed();
+        if (allowed.error || !allowed.isAllowed) return;
+        const result = await getAddress();
+        if (!result.error && result.address) {
+          setWalletAddress(result.address);
+        }
+      } catch {}
+    };
+    restore();
+  }, []);
+
+  const truncate = (addr: string) => `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+
+  return (
+    <div className="w-full max-w-[640px] flex flex-col items-center pt-12">
+      <StepIndicator variant="bars" totalSteps={3} currentStep={3} />
+
+      <div className="w-20 h-20 bg-[var(--db-surface)] border border-[var(--db-primary-container)] rounded-[8px] flex items-center justify-center shadow-[0_0_24px_rgba(200,242,50,0.15)]">
+        <CircleCheck size={48} className="text-[var(--db-primary-container)]" />
+      </div>
+
+      <h1 className="font-sora text-[56px] font-extrabold text-[var(--db-on-surface)] text-center leading-tight mt-6">
+        You&apos;re all set!
+      </h1>
+      <p className="font-geist text-[18px] text-[var(--db-on-surface-variant)] text-center mt-3 max-w-[480px]">
+        Your decentralised identity is now live on the Stellar network. You are
+        ready to explore the marketplace.
+      </p>
+
+      <div className="w-full mt-10 grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div className="bg-[var(--db-surface)] border border-[var(--db-outline-variant)] rounded-[8px] px-6 py-5">
+          <span className="font-geist text-[10px] font-semibold uppercase text-[var(--db-on-surface-variant)]">
+            STATUS
+          </span>
+          <div className="flex items-center gap-2 mt-2">
+            <ShieldCheck
+              size={20}
+              className="text-[var(--db-primary-container)]"
+            />
+            <span className="font-sora text-[20px] font-semibold text-[var(--db-on-surface)]">
+              Account Created
+            </span>
+          </div>
+        </div>
+
+        <div className="bg-[var(--db-surface)] border border-[var(--db-outline-variant)] rounded-[8px] px-6 py-5">
+          <span className="font-geist text-[10px] font-semibold uppercase text-[var(--db-on-surface-variant)]">
+            ROLE
+          </span>
+          <div className="flex items-center gap-2 mt-2">
+            <Briefcase
+              size={20}
+              className="text-[var(--db-primary-container)]"
+            />
+            <span className="font-sora text-[20px] font-semibold text-[var(--db-on-surface)]">
+              BUSINESS
+            </span>
+          </div>
+        </div>
+
+        <div className="md:col-span-2 bg-[var(--db-surface)] border border-[var(--db-outline-variant)] rounded-[8px] px-6 py-5">
+          <span className="font-geist text-[10px] font-semibold uppercase text-[var(--db-on-surface-variant)]">
+            STELLAR WALLET CONNECTED
+          </span>
+          <div className="flex items-center justify-between mt-2">
+            <div className="flex items-center gap-2">
+              <Wallet
+                size={18}
+                className="text-[var(--db-primary-container)]"
+              />
+              <span className="font-mono text-[15px] text-[var(--db-on-surface)]">
+                {walletAddress ? truncate(walletAddress) : "GC4Y...9K2L"}
+              </span>
+            </div>
+            <span className="text-[11px] font-geist font-semibold uppercase text-[var(--db-primary-container)] border border-[var(--db-primary-container)] rounded-[4px] px-2 py-0.5">
+              Active
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 w-full mt-10">
+        <button
+          onClick={() => router.push("/dashboard")}
+          className="w-full sm:flex-1 h-[56px] rounded-[4px] bg-[var(--db-primary-container)] text-[var(--db-on-primary)] font-geist text-[14px] font-semibold uppercase tracking-[0.05em] px-8 whitespace-nowrap hover:opacity-90 transition-opacity "
+        >
+          ENTER DASHBOARD{" "}
+          <ArrowRight size={16} className="inline mb-[2px] ml-0.5" />
+        </button>
+        <button
+          onClick={() => router.push("/dashboard/business")}
+          className="w-full sm:flex-1 h-[56px] rounded-[4px] border border-[var(--db-on-surface)] text-[var(--db-on-surface)] font-geist text-[14px] font-semibold uppercase px-8 whitespace-nowrap hover:bg-[var(--db-surface-high)] transition-colors"
+        >
+          VIEW PROFILE
+        </button>
+      </div>
+
+      <footer className="w-full mt-16 pt-4 border-t border-[var(--db-outline-variant)]">
+        <div className="flex items-center justify-between text-[11px] font-geist text-[var(--db-on-surface-variant)]">
+          <div className="flex items-center gap-2">
+            <Lock size={14} />
+            <span className="uppercase">SECURE DECENTRALISED VERIFICATION</span>
+          </div>
+          <div className="flex gap-4">
+            <span className="cursor-pointer text-[var(--db-on-surface-variant)] hover:text-[var(--db-primary-container)] transition-colors uppercase hover:underline underline-offset-4 decoration-[var(--db-primary-container)]">
+              STELLAR EXPERT
+            </span>
+            <span className="cursor-pointer text-[var(--db-on-surface-variant)] hover:text-[var(--db-primary-container)] transition-colors uppercase hover:underline underline-offset-4 decoration-[var(--db-primary-container)]">
+              HELP CENTER
+            </span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/frontend/app/onboarding/complete/creator/page.tsx
+++ b/apps/frontend/app/onboarding/complete/creator/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import {
+  ArrowRight,
+  CheckCircle2,
+  ShieldCheck,
+  Wallet,
+  TrendingUp,
+} from "lucide-react";
+import { getAddress, isAllowed, isConnected } from "@stellar/freighter-api";
+import { StepIndicator } from "@/components/onboarding/step-indicator";
+
+const STORAGE_KEY = "adsbazaar_onboarding";
+
+const RADIUS = 18;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const TRUST_SCORE = 720;
+const TRUST_MAX = 1000;
+const FILL_PCT = TRUST_SCORE / TRUST_MAX;
+
+export default function CreatorCompletionPage() {
+  const router = useRouter();
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } catch {}
+
+    const restore = async () => {
+      try {
+        const connected = await isConnected();
+        if (connected.error || !connected.isConnected) return;
+        const allowed = await isAllowed();
+        if (allowed.error || !allowed.isAllowed) return;
+        const result = await getAddress();
+        if (!result.error && result.address) {
+          setWalletAddress(result.address);
+        }
+      } catch {}
+    };
+    restore();
+  }, []);
+
+  const truncate = (addr: string) =>
+    `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+
+  return (
+    <div className="w-full min-h-screen bg-[#131313] flex flex-col items-center relative">
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            "radial-gradient(ellipse 80% 60% at 50% 30%, rgba(0,180,100,0.08), transparent 70%)",
+        }}
+      />
+      <div className="w-full max-w-[900px] flex flex-col items-center px-4 py-12 relative z-10">
+        <StepIndicator
+          variant="labeled"
+          totalSteps={3}
+          currentStep={3}
+        />
+
+        <div className="w-20 h-20 bg-[var(--db-primary-container)] rounded-[8px] flex items-center justify-center">
+          <CheckCircle2 size={48} className="text-[var(--db-on-primary)]" />
+        </div>
+
+        <h1 className="font-sora text-[72px] md:text-[72px] text-[40px] font-extrabold text-[var(--db-on-surface)] text-center leading-tight mt-6">
+          Welcome to the Bazaar!
+        </h1>
+        <p className="font-geist text-[18px] text-[var(--db-on-surface-variant)] text-center mt-3 max-w-[560px]">
+          Your decentralized creator journey starts now. We&apos;ve verified your
+          credentials and initialized your presence on the Stellar network.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 w-full mt-12">
+          <div className="bg-[var(--db-surface)] border border-[var(--db-outline-variant)] rounded-[8px] p-6 flex flex-col">
+            <div className="w-10 h-10 bg-[var(--db-surface-high)] rounded-[4px] flex items-center justify-center">
+              <ShieldCheck
+                size={20}
+                className="text-[var(--db-primary-container)]"
+              />
+            </div>
+            <h3 className="font-sora text-[18px] font-semibold text-[var(--db-on-surface)] mt-4">
+              Creator Profile
+            </h3>
+            <p className="font-geist text-[14px] text-[var(--db-on-surface-variant)] mt-2 leading-relaxed flex-1">
+              Your profile is now discoverable by top brands looking for
+              authentic storytellers.
+            </p>
+            <div className="flex items-center gap-2 mt-6">
+              <div className="w-2 h-2 rounded-full bg-[var(--db-primary-container)]" />
+              <span className="font-geist text-[11px] uppercase text-[var(--db-primary-container)] font-semibold">
+                LIVE ON NETWORK
+              </span>
+            </div>
+          </div>
+
+          <div className="bg-[var(--db-surface)] border border-[var(--db-outline-variant)] rounded-[8px] p-6 flex flex-col">
+            <div className="w-10 h-10 bg-[var(--db-surface-high)] rounded-[4px] flex items-center justify-center">
+              <Wallet
+                size={20}
+                className="text-[var(--db-primary-container)]"
+              />
+            </div>
+            <h3 className="font-sora text-[18px] font-semibold text-[var(--db-on-surface)] mt-4">
+              Wallet Ready
+            </h3>
+            <p className="font-geist text-[14px] text-[var(--db-on-surface-variant)] mt-2 leading-relaxed flex-1">
+              Payouts are automated via Stellar smart contracts. Funds will
+              settle directly to your vault.
+            </p>
+            <div className="flex items-center justify-between w-full bg-[var(--db-surface-high)] border border-[var(--db-outline-variant)] rounded-[4px] px-3 py-1.5 mt-6">
+              <span className="font-geist text-[10px] uppercase text-[var(--db-on-surface-variant)]">
+                VAULT ADDRESS
+              </span>
+              <span className="font-mono text-[13px] text-[var(--db-on-surface)]">
+                {walletAddress ? truncate(walletAddress) : "GBX4...3Z9K"}
+              </span>
+            </div>
+          </div>
+
+          <div className="bg-[var(--db-surface)] border border-[var(--db-outline-variant)] rounded-[8px] p-6 flex flex-col">
+            <div className="w-10 h-10 bg-[var(--db-surface-high)] rounded-[4px] flex items-center justify-center">
+              <TrendingUp
+                size={20}
+                className="text-[var(--db-primary-container)]"
+              />
+            </div>
+            <h3 className="font-sora text-[18px] font-semibold text-[var(--db-on-surface)] mt-4">
+              Trust Score
+            </h3>
+            <p className="font-geist text-[14px] text-[var(--db-on-surface-variant)] mt-2 leading-relaxed flex-1">
+              Initial reputation anchor established. Complete your first campaign
+              to boost your tier.
+            </p>
+            <div className="flex items-center justify-between mt-6">
+              <div>
+                <span className="font-sora text-[32px] font-bold text-[var(--db-primary-container)]">
+                  {TRUST_SCORE}
+                </span>
+                <span className="font-geist text-[11px] uppercase text-[var(--db-on-surface-variant)] ml-2">
+                  PRIME TIER
+                </span>
+              </div>
+              <svg width="44" height="44" viewBox="0 0 44 44">
+                <circle
+                  cx="22"
+                  cy="22"
+                  r={RADIUS}
+                  fill="none"
+                  stroke="var(--db-outline-variant)"
+                  strokeWidth="4"
+                />
+                <circle
+                  cx="22"
+                  cy="22"
+                  r={RADIUS}
+                  fill="none"
+                  stroke="var(--db-primary-container)"
+                  strokeWidth="4"
+                  strokeDasharray={CIRCUMFERENCE}
+                  strokeDashoffset={CIRCUMFERENCE * (1 - FILL_PCT)}
+                  strokeLinecap="round"
+                  transform="rotate(-90 22 22)"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3 w-full mt-12">
+          <button
+            onClick={() => router.push("/dashboard/creator")}
+            className="w-full sm:flex-1 h-[56px] rounded-[4px] bg-[var(--db-primary-container)] text-[var(--db-on-primary)] font-geist text-[14px] font-semibold uppercase tracking-[0.05em] px-8 hover:opacity-90 transition-opacity"
+          >
+            EXPLORE CAMPAIGNS <ArrowRight size={16} className="inline" />
+          </button>
+          <button
+            onClick={() => router.push("/dashboard/creator")}
+            className="w-full sm:flex-1 h-[56px] rounded-[4px] border border-[var(--db-on-surface)] text-[var(--db-on-surface)] font-geist text-[14px] font-semibold uppercase px-8 hover:bg-[var(--db-surface-high)] transition-colors"
+          >
+            GO TO DASHBOARD
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/onboarding/creator/page.tsx
+++ b/apps/frontend/app/onboarding/creator/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { ShieldCheck, Lock, Zap } from "lucide-react";
+import { StepIndicator } from "@/components/onboarding/step-indicator";
+import { CreatorForm } from "@/components/onboarding/creator-form";
+
+const STORAGE_KEY = "adsbazaar_onboarding";
+
+function loadDraft() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed.creatorForm) return parsed.creatorForm;
+    }
+  } catch {}
+  return {
+    displayName: "",
+    category: "",
+    country: "",
+    audienceSize: "",
+    socialLink: "",
+    bio: "",
+  };
+}
+
+function saveDraft(data: Record<string, string>) {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    const existing = raw ? JSON.parse(raw) : {};
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...existing, step: 2, role: "creator", creatorForm: data }),
+    );
+  } catch {}
+}
+
+export default function CreatorRegistrationPage() {
+  const router = useRouter();
+  const [data, setData] = useState(loadDraft);
+
+  useEffect(() => {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed.creatorForm) setData(parsed.creatorForm);
+      } catch {}
+    }
+  }, []);
+
+  const handleChange = (next: typeof data) => {
+    setData(next);
+    saveDraft(next);
+  };
+
+  return (
+    <div className="w-full max-w-[540px]">
+      <StepIndicator
+        variant="bars"
+        totalSteps={3}
+        currentStep={2}
+        label="Creator Registration"
+      />
+      <div className="bg-[var(--db-surface)] border border-[var(--db-outline-variant)] rounded-[8px] overflow-hidden">
+        <CreatorForm
+          data={data}
+          onChange={handleChange}
+          onSubmit={() => router.push("/onboarding/complete/creator")}
+          onSkip={() => router.push("/dashboard/creator")}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-start justify-center gap-x-10 gap-y-4 w-full mt-12 mb-6">
+        <div className="flex flex-col items-center gap-1 min-w-28">
+          <ShieldCheck size={24} className="text-[var(--db-primary-container)]" />
+          <span className="font-geist text-[12px] text-[var(--db-on-surface-variant)] text-center">
+            Verified on Stellar
+          </span>
+        </div>
+        <div className="flex flex-col items-center gap-1 min-w-28">
+          <Lock size={24} className="text-[var(--db-primary-container)]" />
+          <span className="font-geist text-[12px] text-[var(--db-on-surface-variant)] text-center">
+            Privacy Protected
+          </span>
+        </div>
+        <div className="flex flex-col items-center gap-1 min-w-28">
+          <Zap size={24} className="text-[var(--db-primary-container)]" />
+          <span className="font-geist text-[12px] text-[var(--db-on-surface-variant)] text-center">
+            Instant Payouts
+          </span>
+        </div>
+      </div>
+
+      <div className="w-full h-px bg-[var(--db-outline-variant)]" />
+
+      <footer className="w-full mt-6">
+        <p className="text-[11px] font-geist text-[var(--db-on-surface-variant)] text-center">
+          © 2024 ADSBAZAAR PROTOCOL. ALL RIGHTS RESERVED.
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/apps/frontend/app/onboarding/layout.tsx
+++ b/apps/frontend/app/onboarding/layout.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { OnboardingHeader } from "@/components/onboarding/onboarding-header";
+
+export default function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const isStep1 =
+    pathname === "/onboarding/role" || pathname === "/onboarding";
+
+  return (
+    <div className="min-h-screen bg-[#131313] flex flex-col">
+      <OnboardingHeader variant={isStep1 ? "wallet" : "support"} />
+      <main className="flex-1 flex flex-col items-center px-4 py-12">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/apps/frontend/app/onboarding/page.tsx
+++ b/apps/frontend/app/onboarding/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function OnboardingPage() {
+  redirect("/onboarding/role");
+}

--- a/apps/frontend/app/onboarding/role/page.tsx
+++ b/apps/frontend/app/onboarding/role/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Suspense, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { LayoutGrid, Sparkles } from "lucide-react";
+import { StepIndicator } from "@/components/onboarding/step-indicator";
+import { RoleCard } from "@/components/onboarding/role-card";
+
+function RoleContent() {
+  const searchParams = useSearchParams();
+  const intent = searchParams.get("intent");
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(
+        "adsbazaar_onboarding",
+        JSON.stringify({
+          role:
+            intent === "creator"
+              ? "creator"
+              : intent === "business"
+                ? "business"
+                : null,
+          step: 1,
+          businessForm: null,
+          creatorForm: null,
+        }),
+      );
+    } catch {}
+  }, [intent]);
+
+  return (
+    <>
+      <StepIndicator variant="dots" totalSteps={2} currentStep={1} />
+
+      <h1 className="font-sora text-[40px] font-extrabold text-[var(--db-on-surface)] text-center leading-tight">
+        Select your journey.
+      </h1>
+      <p className="font-geist text-[16px] text-[var(--db-on-surface-variant)] text-center mt-3 max-w-[560px]">
+        Welcome to the AdsBazaar ecosystem. Choose how you want to participate
+        in the creator economy.
+      </p>
+
+      <div className="flex flex-col md:flex-row gap-6 mt-10">
+        <RoleCard
+          role="business"
+          icon={<LayoutGrid size={20} />}
+          title="I am a Business"
+          description="Launch creator campaigns, fund escrow, and manage creator relationships from one dashboard."
+          href="/onboarding/business"
+          highlighted={intent === "business"}
+        />
+        <RoleCard
+          role="creator"
+          icon={<Sparkles size={20} />}
+          title="I am a Creator"
+          description="Discover campaigns, apply with your profile, submit content, and get paid instantly."
+          href="/onboarding/creator"
+          highlighted={intent === "creator"}
+        />
+      </div>
+
+      <footer className="w-full mt-auto pt-16">
+        <div className="h-px bg-[var(--db-outline-variant)] mb-4" />
+        <div className="flex items-center justify-between text-[11px] font-geist text-[var(--db-on-surface-variant)]">
+          <span>© 2024 ADSBAZAAR. BUILT ON STELLAR.</span>
+          <div className="flex gap-4">
+            <span className="cursor-pointer hover:text-[var(--db-primary-container)] transition-colors hover:underline underline-offset-4 decoration-[var(--db-primary-container)]">
+              TERMS
+            </span>
+            <span className="cursor-pointer hover:text-[var(--db-primary-container)] transition-colors hover:underline underline-offset-4 decoration-[var(--db-primary-container)]">
+              PRIVACY
+            </span>
+          </div>
+        </div>
+      </footer>
+    </>
+  );
+}
+
+export default function RoleSelectionPage() {
+  return (
+    <div className="w-full max-w-[960px] flex-1 flex flex-col items-center">
+      <Suspense fallback={null}>
+        <RoleContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/frontend/components/landing/FinalCta.tsx
+++ b/apps/frontend/components/landing/FinalCta.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export function FinalCta() {
   return (
     <section className="py-12 md:py-[80px] px-6 max-w-[1280px] mx-auto">
@@ -8,9 +10,12 @@ export function FinalCta() {
         <p className="font-geist text-[16px] md:text-[18px] text-on-surface-variant mb-10 max-w-[600px] mx-auto">
           Join the marketplace where trust is decentralized and growth is global.
         </p>
-        <button className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[56px] px-10 rounded-[4px] hover:opacity-90 transition-opacity">
+        <Link
+          href="/onboarding/role?intent=business"
+          className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[56px] px-10 rounded-[4px] inline-flex items-center justify-center hover:opacity-90 transition-opacity"
+        >
           Launch a Campaign
-        </button>
+        </Link>
       </div>
     </section>
   );

--- a/apps/frontend/components/landing/Hero.tsx
+++ b/apps/frontend/components/landing/Hero.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export function Hero() {
   return (
     <section className="min-h-screen flex items-center justify-center pt-20 px-6">
@@ -9,12 +11,18 @@ export function Hero() {
           The Trust Layer for Global Creator Campaigns.
         </h1>
         <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
-          <button className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] w-full sm:w-auto hover:opacity-90 transition-opacity">
+          <Link
+            href="/onboarding/role?intent=business"
+            className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] w-full sm:w-auto inline-flex items-center justify-center hover:opacity-90 transition-opacity"
+          >
             Start a campaign
-          </button>
-          <button className="bg-transparent border border-on-surface text-on-surface font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] w-full sm:w-auto hover:bg-surface-container transition-colors">
+          </Link>
+          <Link
+            href="/onboarding/role?intent=creator"
+            className="bg-transparent border border-on-surface text-on-surface font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] w-full sm:w-auto inline-flex items-center justify-center hover:bg-surface-container transition-colors"
+          >
             Find campaigns
-          </button>
+          </Link>
         </div>
       </div>
     </section>

--- a/apps/frontend/components/onboarding/business-form.tsx
+++ b/apps/frontend/components/onboarding/business-form.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { InputHTMLAttributes, useState } from "react";
+import { Mail, Link as LinkIcon, ArrowRight } from "lucide-react";
+
+type BusinessFormData = {
+  name: string;
+  industry: string;
+  country: string;
+  email: string;
+  website: string;
+  description: string;
+};
+
+type BusinessFormProps = {
+  data: BusinessFormData;
+  onChange: (data: BusinessFormData) => void;
+  onSubmit: () => void;
+  onBack: () => void;
+};
+
+const INDUSTRIES = [
+  "Technology",
+  "Fashion & Beauty",
+  "Food & Beverage",
+  "Gaming",
+  "Finance",
+  "Health & Wellness",
+  "Entertainment",
+  "Education",
+  "Other",
+];
+
+const COUNTRIES = [
+  "Nigeria",
+  "Kenya",
+  "South Africa",
+  "Ghana",
+  "United States",
+  "United Kingdom",
+  "Germany",
+  "Brazil",
+  "Indonesia",
+  "Other",
+];
+
+type Errors = Partial<Record<keyof BusinessFormData, string>>;
+
+function validate(data: BusinessFormData): Errors {
+  const errors: Errors = {};
+  if (!data.name || data.name.trim().length < 2) {
+    errors.name = "Business Name is required (min 2 chars)";
+  }
+  if (!data.industry) {
+    errors.industry = "Please select an industry";
+  }
+  if (!data.country) {
+    errors.country = "Please select a country";
+  }
+  if (!data.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+    errors.email = "Valid email is required";
+  }
+  if (data.website && !/^https:\/\//.test(data.website)) {
+    errors.website = "URL must start with https://";
+  }
+  return errors;
+}
+
+export function BusinessForm({
+  data,
+  onChange,
+  onSubmit,
+  onBack,
+}: BusinessFormProps) {
+  const [errors, setErrors] = useState<Errors>({});
+  const [touched, setTouched] = useState<Set<string>>(new Set());
+
+  const handleChange = (field: keyof BusinessFormData, value: string) => {
+    const next = { ...data, [field]: value };
+    onChange(next);
+    if (touched.has(field)) {
+      const errs = validate(next);
+      setErrors((prev) => {
+        const updated = { ...prev };
+        if (errs[field]) {
+          updated[field] = errs[field]!;
+        } else {
+          delete updated[field];
+        }
+        return updated;
+      });
+    }
+  };
+
+  const handleBlur = (field: keyof BusinessFormData) => {
+    setTouched((prev) => new Set(prev).add(field));
+    const errs = validate(data);
+    if (errs[field]) {
+      setErrors((prev) => ({ ...prev, [field]: errs[field]! }));
+    } else {
+      setErrors((prev) => {
+        const updated = { ...prev };
+        delete updated[field];
+        return updated;
+      });
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs = validate(data);
+    setErrors(errs);
+    setTouched(new Set(["name", "industry", "country", "email", "website"]));
+    if (Object.keys(errs).length === 0) {
+      onSubmit();
+    }
+  };
+
+  const inputClass = (field: keyof BusinessFormData) =>
+    `w-full h-12 bg-[var(--db-surface-high)] border ${
+      errors[field] && touched.has(field)
+        ? "border-[#ef4444]"
+        : "border-[var(--db-outline-variant)]"
+    } rounded-[4px] px-3 text-[14px] font-geist text-[var(--db-on-surface)] outline-none transition-colors focus:border-[var(--db-primary-container)] placeholder:text-[var(--db-on-surface-variant)]`;
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="flex flex-col md:flex-row gap-0">
+        <div className="flex-1 p-8">
+          <h2 className="font-sora text-[24px] font-semibold text-[var(--db-on-surface)]">
+            Business Identity
+          </h2>
+          <p className="font-geist text-[14px] text-[var(--db-on-surface-variant)] mt-2 mb-6">
+            Define how you will appear in the creator marketplace. This
+            information helps us tailor your campaign opportunities.
+          </p>
+
+          <div className="space-y-5">
+            <div>
+              <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                Business Name
+              </label>
+              <input
+                className={inputClass("name")}
+                placeholder="e.g. Atlas Digital Group"
+                value={data.name}
+                onChange={(e) => handleChange("name", e.target.value)}
+                onBlur={() => handleBlur("name")}
+              />
+              {errors.name && touched.has("name") && (
+                <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                  {errors.name}
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-col md:flex-row gap-4">
+              <div className="flex-1">
+                <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                  Industry
+                </label>
+                <select
+                  className={inputClass("industry")}
+                  value={data.industry}
+                  onChange={(e) => handleChange("industry", e.target.value)}
+                  onBlur={() => handleBlur("industry")}
+                >
+                  <option value="">Select Industry</option>
+                  {INDUSTRIES.map((ind) => (
+                    <option key={ind} value={ind}>
+                      {ind}
+                    </option>
+                  ))}
+                </select>
+                {errors.industry && touched.has("industry") && (
+                  <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                    {errors.industry}
+                  </p>
+                )}
+              </div>
+              <div className="flex-1">
+                <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                  Country
+                </label>
+                <select
+                  className={inputClass("country")}
+                  value={data.country}
+                  onChange={(e) => handleChange("country", e.target.value)}
+                  onBlur={() => handleBlur("country")}
+                >
+                  <option value="">Select Country</option>
+                  {COUNTRIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+                {errors.country && touched.has("country") && (
+                  <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                    {errors.country}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                Business Email
+              </label>
+              <div className="relative">
+                <Mail
+                  size={16}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--db-on-surface-variant)]"
+                />
+                <input
+                  className={`${inputClass("email")} pl-9`}
+                  placeholder="hello@yourbusiness.com"
+                  type="email"
+                  value={data.email}
+                  onChange={(e) => handleChange("email", e.target.value)}
+                  onBlur={() => handleBlur("email")}
+                />
+              </div>
+              {errors.email && touched.has("email") && (
+                <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                  {errors.email}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                Website or Social Link
+              </label>
+              <div className="relative">
+                <LinkIcon
+                  size={16}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--db-on-surface-variant)]"
+                />
+                <input
+                  className={`${inputClass("website")} pl-9`}
+                  placeholder="https://"
+                  type="url"
+                  value={data.website}
+                  onChange={(e) => handleChange("website", e.target.value)}
+                  onBlur={() => handleBlur("website")}
+                />
+              </div>
+              {errors.website && touched.has("website") && (
+                <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                  {errors.website}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                Brief Description
+              </label>
+              <textarea
+                className={`${inputClass("description")} min-h-[96px] resize-none py-3`}
+                placeholder="Tell us about your brand vision..."
+                rows={4}
+                value={data.description}
+                onChange={(e) => handleChange("description", e.target.value)}
+              />
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button
+                type="submit"
+                className="flex-1 h-12 rounded-[4px] bg-[var(--db-primary-container)] text-[var(--db-on-primary)] font-geist text-[13px] font-semibold hover:opacity-90 transition-opacity"
+              >
+                Continue to Dashboard{" "}
+                <ArrowRight size={16} className="inline mb-[2px] ml-0.5" />
+              </button>
+              <button
+                type="button"
+                onClick={onBack}
+                className="h-12 px-6 rounded-[4px] border border-[var(--db-on-surface)] text-[var(--db-on-surface)] font-geist text-[13px] font-semibold hover:bg-[var(--db-surface-high)] transition-colors"
+              >
+                Back
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="hidden md:flex flex-col justify-between w-[42%] p-8 border-l border-[var(--db-outline-variant)]">
+          <div className="self-end">
+            <svg
+              width="64"
+              height="64"
+              viewBox="0 0 64 64"
+              fill="none"
+              style={{ transform: "rotate(6deg)" }}
+            >
+              <path
+                d="M32 4L52 12V28C52 42 40 54 32 58C24 54 12 42 12 28V12L32 4Z"
+                stroke="#343332"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M24 32L30 38L40 26"
+                stroke="#343332"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+          <div>
+            <div className="w-8 h-0.5 bg-[var(--db-primary-container)] mb-4" />
+            <h3 className="font-sora text-[20px] font-semibold text-[var(--db-on-surface)]">
+              Verified for Creators.
+            </h3>
+            <p className="font-geist text-[14px] text-[var(--db-on-surface-variant)] mt-3 leading-relaxed">
+              Completing your profile unlocks the AdsBazaar verified badge,
+              increasing response rates from top-tier talent by 40%.
+            </p>
+          </div>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/apps/frontend/components/onboarding/creator-form.tsx
+++ b/apps/frontend/components/onboarding/creator-form.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useState } from "react";
+import { Users, Link as LinkIcon, ArrowRight } from "lucide-react";
+
+type CreatorFormData = {
+  displayName: string;
+  category: string;
+  country: string;
+  audienceSize: string;
+  socialLink: string;
+  bio: string;
+};
+
+type CreatorFormProps = {
+  data: CreatorFormData;
+  onChange: (data: CreatorFormData) => void;
+  onSubmit: () => void;
+  onSkip: () => void;
+};
+
+const CATEGORIES = [
+  "Gaming",
+  "Lifestyle",
+  "Tech",
+  "Fashion",
+  "Food",
+  "Finance",
+  "Travel",
+  "Education",
+  "Fitness",
+  "Music",
+  "Art",
+  "Other",
+];
+
+const COUNTRIES = [
+  "Nigeria",
+  "Kenya",
+  "South Africa",
+  "Ghana",
+  "United States",
+  "United Kingdom",
+  "Germany",
+  "Brazil",
+  "Indonesia",
+  "Other",
+];
+
+const AUDIENCE_SIZES = [
+  "Under 1K",
+  "1K–10K",
+  "10K–100K",
+  "100K–500K",
+  "500K–1M",
+  "1M+",
+];
+
+const BIO_MAX = 160;
+
+type Errors = Partial<Record<keyof CreatorFormData, string>>;
+
+function validate(data: CreatorFormData): Errors {
+  const errors: Errors = {};
+  if (!data.displayName || data.displayName.trim().length < 2) {
+    errors.displayName = "Display Name is required (min 2 chars)";
+  }
+  if (!data.category) {
+    errors.category = "Please select a niche";
+  }
+  if (!data.country) {
+    errors.country = "Please select a region";
+  }
+  if (!data.audienceSize) {
+    errors.audienceSize = "Please select a range";
+  }
+  if (!data.socialLink || !/^https:\/\//.test(data.socialLink)) {
+    errors.socialLink = "A valid https:// link is required";
+  }
+  if (!data.bio || data.bio.trim().length === 0) {
+    errors.bio = "Short bio is required";
+  } else if (data.bio.length > BIO_MAX) {
+    errors.bio = `Bio must be ${BIO_MAX} characters or less`;
+  }
+  return errors;
+}
+
+export function CreatorForm({
+  data,
+  onChange,
+  onSubmit,
+  onSkip,
+}: CreatorFormProps) {
+  const [errors, setErrors] = useState<Errors>({});
+  const [touched, setTouched] = useState<Set<string>>(new Set());
+
+  const handleChange = (field: keyof CreatorFormData, value: string) => {
+    const next = { ...data, [field]: value };
+    onChange(next);
+    if (touched.has(field)) {
+      const errs = validate(next);
+      setErrors((prev) => {
+        const updated = { ...prev };
+        if (errs[field]) {
+          updated[field] = errs[field]!;
+        } else {
+          delete updated[field];
+        }
+        return updated;
+      });
+    }
+  };
+
+  const handleBlur = (field: keyof CreatorFormData) => {
+    setTouched((prev) => new Set(prev).add(field));
+    const errs = validate(data);
+    if (errs[field]) {
+      setErrors((prev) => ({ ...prev, [field]: errs[field]! }));
+    } else {
+      setErrors((prev) => {
+        const updated = { ...prev };
+        delete updated[field];
+        return updated;
+      });
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs = validate(data);
+    setErrors(errs);
+    setTouched(
+      new Set([
+        "displayName",
+        "category",
+        "country",
+        "audienceSize",
+        "socialLink",
+        "bio",
+      ]),
+    );
+    if (Object.keys(errs).length === 0) {
+      onSubmit();
+    }
+  };
+
+  const inputClass = (field: keyof CreatorFormData) =>
+    `w-full h-12 bg-[var(--db-surface-high)] border ${
+      errors[field] && touched.has(field)
+        ? "border-[#ef4444]"
+        : "border-[var(--db-outline-variant)]"
+    } rounded-[4px] px-3 text-[14px] font-geist text-[var(--db-on-surface)] outline-none transition-colors focus:border-[var(--db-primary-container)] placeholder:text-[var(--db-on-surface-variant)]`;
+
+  const charsLeft = BIO_MAX - data.bio.length;
+  const nearLimit = charsLeft <= 20;
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="p-8">
+        <h2 className="font-sora text-[24px] font-semibold text-[var(--db-on-surface)]">
+          Define your creator profile
+        </h2>
+        <p className="font-geist text-[14px] text-[var(--db-on-surface-variant)] mt-2 mb-6">
+          Help us tailor the best sponsorship opportunities for your specific
+          audience and niche.
+        </p>
+
+        <div className="space-y-5">
+          <div>
+            <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+              Display Name
+            </label>
+            <input
+              className={inputClass("displayName")}
+              placeholder="e.g. Alex Creator"
+              value={data.displayName}
+              onChange={(e) => handleChange("displayName", e.target.value)}
+              onBlur={() => handleBlur("displayName")}
+            />
+            {errors.displayName && touched.has("displayName") && (
+              <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                {errors.displayName}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="flex-1">
+              <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                Category
+              </label>
+              <select
+                className={inputClass("category")}
+                value={data.category}
+                onChange={(e) => handleChange("category", e.target.value)}
+                onBlur={() => handleBlur("category")}
+              >
+                <option value="">Select Niche</option>
+                {CATEGORIES.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {cat}
+                  </option>
+                ))}
+              </select>
+              {errors.category && touched.has("category") && (
+                <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                  {errors.category}
+                </p>
+              )}
+            </div>
+            <div className="flex-1">
+              <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                Country
+              </label>
+              <select
+                className={inputClass("country")}
+                value={data.country}
+                onChange={(e) => handleChange("country", e.target.value)}
+                onBlur={() => handleBlur("country")}
+              >
+                <option value="">Primary Region</option>
+                {COUNTRIES.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+              {errors.country && touched.has("country") && (
+                <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                  {errors.country}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="flex-1">
+              <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                Audience Size
+              </label>
+              <div className="relative">
+                <Users
+                  size={16}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--db-on-surface-variant)]"
+                />
+                <select
+                  className={`${inputClass("audienceSize")} pl-9`}
+                  value={data.audienceSize}
+                  onChange={(e) => handleChange("audienceSize", e.target.value)}
+                  onBlur={() => handleBlur("audienceSize")}
+                >
+                  <option value="">Follower Range</option>
+                  {AUDIENCE_SIZES.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {errors.audienceSize && touched.has("audienceSize") && (
+                <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                  {errors.audienceSize}
+                </p>
+              )}
+            </div>
+            <div className="flex-1">
+              <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+                Primary Social Link
+              </label>
+              <div className="relative">
+                <LinkIcon
+                  size={16}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--db-on-surface-variant)]"
+                />
+                <input
+                  className={`${inputClass("socialLink")} pl-9`}
+                  placeholder="https://"
+                  type="url"
+                  value={data.socialLink}
+                  onChange={(e) => handleChange("socialLink", e.target.value)}
+                  onBlur={() => handleBlur("socialLink")}
+                />
+              </div>
+              {errors.socialLink && touched.has("socialLink") && (
+                <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                  {errors.socialLink}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <label className="block font-geist text-[12px] font-semibold uppercase text-[var(--db-on-surface-variant)] mb-1">
+              Short Bio
+            </label>
+            <textarea
+              className={`${inputClass("bio")} min-h-[96px] resize-none py-3`}
+              placeholder="Tell brands what makes your content unique..."
+              rows={4}
+              maxLength={BIO_MAX + 20}
+              value={data.bio}
+              onChange={(e) => handleChange("bio", e.target.value)}
+              onBlur={() => handleBlur("bio")}
+            />
+            <div className="flex items-center justify-end mt-1">
+              <span
+                className={`font-geist text-[10px] uppercase ${
+                  nearLimit
+                    ? "text-[#ef4444]"
+                    : "text-[var(--db-on-surface-variant)]"
+                }`}
+              >
+                {data.bio.length} / {BIO_MAX} CHARACTERS
+              </span>
+            </div>
+            {errors.bio && touched.has("bio") && (
+              <p className="font-geist text-[12px] text-[#ef4444] mt-1">
+                {errors.bio}
+              </p>
+            )}
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <button
+              type="submit"
+              className="flex-1 h-12 rounded-[4px] bg-[var(--db-primary-container)] text-[var(--db-on-primary)] font-geist text-[13px] font-semibold hover:opacity-90 transition-opacity"
+            >
+              Complete Profile{" "}
+              <ArrowRight size={16} className="inline mb-[2px] ml-0.5" />
+            </button>
+            <button
+              type="button"
+              onClick={onSkip}
+              className="h-12 px-6 rounded-[4px] border border-[var(--db-on-surface)] text-[var(--db-on-surface)] font-geist text-[13px] font-semibold hover:bg-[var(--db-surface-high)] transition-colors"
+            >
+              Skip for Now
+            </button>
+          </div>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/apps/frontend/components/onboarding/onboarding-header.tsx
+++ b/apps/frontend/components/onboarding/onboarding-header.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getAddress,
+  isAllowed,
+  isConnected,
+} from "@stellar/freighter-api";
+import { Wallet } from "lucide-react";
+
+type OnboardingHeaderProps = {
+  variant: "wallet" | "support";
+};
+
+export function OnboardingHeader({ variant }: OnboardingHeaderProps) {
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    const restore = async () => {
+      try {
+        const connected = await isConnected();
+        if (connected.error || !connected.isConnected) return;
+        const allowed = await isAllowed();
+        if (allowed.error || !allowed.isAllowed) return;
+        const result = await getAddress();
+        if (!result.error && result.address) {
+          setWalletAddress(result.address);
+        }
+      } catch {}
+    };
+    restore();
+  }, []);
+
+  const truncate = (addr: string) =>
+    `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+
+  return (
+    <header>
+      <div className="flex items-center justify-between h-14 px-6 max-w-[1200px] mx-auto">
+        <span className="font-sora font-bold text-[20px] text-[var(--db-on-surface)]">
+          AdsBazaar
+        </span>
+        {variant === "wallet" && walletAddress ? (
+          <div className="flex items-center gap-1.5 border border-[var(--db-outline-variant)] rounded-[4px] px-3 py-1.5 text-[13px] font-geist text-[var(--db-on-surface)]">
+            <Wallet size={14} className="text-[var(--db-on-surface-variant)]" />
+            <span>{truncate(walletAddress)}</span>
+          </div>
+        ) : variant === "wallet" ? (
+          <div className="bg-[var(--db-primary-container)] text-[var(--db-on-primary)] rounded-[4px] px-3 py-1.5 text-[13px] font-geist font-semibold">
+            Connect Wallet
+          </div>
+        ) : (
+          <span className="text-[13px] font-geist text-[var(--db-on-surface-variant)] hover:text-[var(--db-on-surface)] transition-colors cursor-pointer">
+            ? SUPPORT
+          </span>
+        )}
+      </div>
+      <div className="h-px bg-[var(--db-outline-variant)]" />
+    </header>
+  );
+}

--- a/apps/frontend/components/onboarding/role-card.tsx
+++ b/apps/frontend/components/onboarding/role-card.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+type RoleCardProps = {
+  role: "business" | "creator";
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  href: string;
+  highlighted?: boolean;
+};
+
+export function RoleCard({
+  icon,
+  title,
+  description,
+  href,
+  highlighted,
+}: RoleCardProps) {
+  return (
+    <Link
+      href={href}
+      className={`flex flex-col bg-[var(--db-surface)] border ${
+        highlighted
+          ? "border-[var(--db-primary-container)]"
+          : "border-[var(--db-outline-variant)]"
+      } rounded-[8px] p-8 w-full md:w-[360px] transition-all duration-150 hover:border-[var(--db-primary-container)] group`}
+    >
+      <div className="w-10 h-10 bg-[var(--db-surface-high)] rounded-[4px] flex items-center justify-center">
+        <span className="text-[var(--db-on-surface)]">{icon}</span>
+      </div>
+      <h3 className="font-sora text-[24px] font-semibold text-[var(--db-on-surface)] mt-6">
+        {title}
+      </h3>
+      <p className="font-geist text-[16px] text-[var(--db-on-surface-variant)] mt-3 leading-relaxed">
+        {description}
+      </p>
+      <span className="font-geist text-[12px] font-semibold uppercase tracking-[0.05em] text-[var(--db-primary-container)] mt-8">
+        SELECT ROLE <ArrowRight size={12} className="inline" />
+      </span>
+    </Link>
+  );
+}

--- a/apps/frontend/components/onboarding/step-indicator.tsx
+++ b/apps/frontend/components/onboarding/step-indicator.tsx
@@ -1,0 +1,105 @@
+type StepIndicatorProps = {
+  totalSteps: number;
+  currentStep: number;
+  variant?: "dots" | "bars" | "labeled";
+  label?: string;
+};
+
+export function StepIndicator({
+  totalSteps,
+  currentStep,
+  variant = "dots",
+  label,
+}: StepIndicatorProps) {
+  if (variant === "dots") {
+    return (
+      <div className="flex items-center justify-center mb-8">
+        {Array.from({ length: totalSteps }, (_, i) => {
+          const step = i + 1;
+          const isActive = step <= currentStep;
+          return (
+            <div key={step} className="flex items-center">
+              <div
+                className={`w-2 h-2 rounded-full transition-colors ${
+                  isActive ? "bg-[var(--db-primary-container)]" : "bg-[var(--db-outline-variant)]"
+                }`}
+              />
+              {step < totalSteps && (
+                <div className="w-10 h-px bg-[var(--db-outline-variant)] mx-3" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (variant === "bars") {
+    return (
+      <div className="mb-8 w-full">
+        <div className={`flex items-center mb-3 ${label ? "justify-between" : "justify-center"}`}>
+          <span className="bg-[var(--db-primary-container)] text-[var(--db-on-primary)] text-[12px] font-geist font-semibold px-2 py-0.5 rounded-[4px]">
+            STEP {String(currentStep).padStart(2, "0")} OF{" "}
+            {String(totalSteps).padStart(2, "0")}
+          </span>
+          {label && (
+            <span className="text-[12px] font-geist text-[var(--db-on-surface)]">
+              {label}
+            </span>
+          )}
+        </div>
+        <div className="flex gap-1 w-full">
+          {Array.from({ length: totalSteps }, (_, i) => {
+            const step = i + 1;
+            const isFilled = step <= currentStep;
+            return (
+              <div
+                key={step}
+                className={`h-1 flex-1 rounded-[2px] ${
+                  isFilled
+                    ? "bg-[var(--db-primary-container)]"
+                    : "bg-[var(--db-outline-variant)]"
+                }`}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-8 w-full max-w-[480px] mx-auto">
+      <div className="flex gap-1 w-full mb-2">
+        {[1, 2, 3].map((step) => (
+          <div
+            key={step}
+            className={`h-1 flex-1 rounded-[2px] ${
+              step <= currentStep
+                ? "bg-[var(--db-primary-container)]"
+                : "bg-[var(--db-outline-variant)]"
+            }`}
+          />
+        ))}
+      </div>
+      <div className="flex gap-1 w-full">
+        {["STEP 01", "STEP 02", "STEP 03"].map((s, i) => {
+          const stepNum = i + 1;
+          const isCurrent = stepNum === currentStep;
+          return (
+            <span
+              key={s}
+              className={`flex-1 text-center text-[10px] font-geist font-semibold uppercase ${
+                isCurrent
+                  ? "text-[var(--db-on-surface)]"
+                  : "text-[var(--db-on-surface-variant)]"
+              }`}
+            >
+              {s}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Builds the full 3-step AdsBazaar onboarding flow. When a user connects their
Stellar wallet and clicks **"Start a campaign"** or **"Find campaigns"** on the
landing page, they enter this role-aware registration experience. Each screen
is a separate route for shareable URLs and working browser back buttons.
 
## What was implemented
 
 ### Changes:
- Add `/onboarding/role` — step 1 role selection with intent query param support
- Add `/onboarding/business` — step 2A business identity form with trust panel
- Add `/onboarding/creator` — step 2B creator profile form with char counter
- Add `/onboarding/complete/business` — step 3A business completion screen
- Add `/onboarding/complete/creator` — step 3B creator completion with trust score ring
- Add `OnboardingLayout` — minimal centered layout (no sidebar/topbar)
- Add reusable components: `StepIndicator`, `RoleCard`, `OnboardingHeader`
- Add `BusinessForm` and `CreatorForm` components with sessionStorage draft saving
- Wire landing page buttons to `/onboarding/role?intent=business|creator`

### Routes (7 new files)
 
| Route | Screen | Description |
|---|---|---|
| `/onboarding` | Redirect | Redirects to `/onboarding/role` |
| `/onboarding/role` | Step 1 | Role selection with intent-based highlighting |
| `/onboarding/business` | Step 2A | Business identity form |
| `/onboarding/creator` | Step 2B | Creator profile form |
| `/onboarding/complete/business` | Step 3A | Business completion screen |
| `/onboarding/complete/creator` | Step 3B | Creator completion screen |
 
### Shared Components (5 new files)
 
- **`OnboardingHeader`** — Two variants (`wallet` / `support`), shows Stellar wallet address or support link
- **`StepIndicator`** — Three visual variants (`dots` / `bars` / `labeled`) for each step context
- **`RoleCard`** — Clickable card with icon, title, description, intent highlighting
- **`BusinessForm`** — 6-field form with industry/country selects, icons, trust panel
- **`CreatorForm`** — 6-field form with audience size select, character counter, skip option
 
### Landing Page Updates (2 modified files)
 
- **`Hero.tsx`** — CTA buttons now link to `/onboarding/role?intent=business|creator`
- **`FinalCta.tsx`** — "Launch a Campaign" button links to the onboarding flow
 
### Key Details
 
- Draft data persisted to `sessionStorage` across steps for resilience
- Wallet state restored from Freighter on completion screens
- Design tokens match the existing app palette (`#131313` background, `#c8f232` lime accents)
- Layout is self-contained — no dependency on the dashboard shell from #9
 
## Screenshots
- #### Screen 1: Role selection — two cards, step dot indicator, wallet address in nav
<img width="1903" height="959" alt="Screenshot 2026-06-18 at 14 40 57" src="https://github.com/user-attachments/assets/f972d65a-4b6f-4a14-80c6-d52389f91474" />

- #### Screen 2A: Business form — two-column card, 5 fields, trust panel on right
<img width="1920" height="955" alt="Screenshot 2026-06-18 at 14 42 08" src="https://github.com/user-attachments/assets/afe314c0-d58a-495d-a347-d85d511b6a32" />


- #### Screen 2B: Creator form — single wide card, 6 fields, character counter on bio
<img width="1908" height="958" alt="Screenshot 2026-06-18 at 14 47 08" src="https://github.com/user-attachments/assets/8e1c16d8-5066-4062-8fb6-7fe6b9ab5e79" />

- #### Screen 3A: Business completion — status cards, wallet address, two CTAs
<img width="1920" height="960" alt="Screenshot 2026-06-18 at 14 44 44" src="https://github.com/user-attachments/assets/745c5ac4-152a-4552-9981-7696c4758a7e" />

- #### Screen 3B: Creator completion — 3 feature cards with live data, trust score ring
<img width="1923" height="959" alt="Screenshot 2026-06-18 at 14 45 45" src="https://github.com/user-attachments/assets/878735fa-a156-49fe-98a9-da4f8c8fb5b5" />

Closes #10