### PR TITLE
Feat/marketplace campaign detail

### DIFF
--- a/apps/frontend/app/marketplace/[id]/page.tsx
+++ b/apps/frontend/app/marketplace/[id]/page.tsx
@@ -1,0 +1,40 @@
+import { Navbar } from "@/components/landing/Navbar";
+import { Footer } from "@/components/landing/Footer";
+import { campaignDetailMock } from "@/components/marketplace/campaign-detail-data";
+import { CampaignDetailHeader } from "@/components/marketplace/campaign-detail-header";
+import { CampaignHeroImage } from "@/components/marketplace/campaign-hero-image";
+import { CampaignBriefSection } from "@/components/marketplace/campaign-brief-section";
+import { CampaignRequirements } from "@/components/marketplace/campaign-requirements";
+import { EscrowSidebar } from "@/components/marketplace/escrow-sidebar";
+import { ApplicationForm } from "@/components/marketplace/application-form";
+import { CampaignHelpCard } from "@/components/marketplace/campaign-help-card";
+
+export default function CampaignDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const campaign = campaignDetailMock;
+
+  return (
+    <>
+      <Navbar />
+      <main className="max-w-[1280px] mx-auto px-6 lg:px-10 pt-28 pb-20">
+        <div className="grid grid-cols-12 gap-8">
+          <div className="col-span-12 lg:col-span-7 flex flex-col gap-8">
+            <CampaignDetailHeader campaign={campaign} />
+            <CampaignHeroImage campaign={campaign} />
+            <CampaignBriefSection campaign={campaign} />
+            <CampaignRequirements requirements={campaign.requirements} />
+          </div>
+          <aside className="col-span-12 lg:col-span-5 flex flex-col gap-6">
+            <EscrowSidebar campaign={campaign} />
+            <ApplicationForm />
+            <CampaignHelpCard />
+          </aside>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/frontend/components/marketplace/application-form.tsx
+++ b/apps/frontend/components/marketplace/application-form.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { campaignDetailMock } from "./campaign-detail-data";
+
+export function ApplicationForm() {
+  const [portfolioLink, setPortfolioLink] = useState("");
+  const [contentFormat, setContentFormat] = useState(
+    campaignDetailMock.contentFormats[0]
+  );
+  const [pitchMessage, setPitchMessage] = useState("");
+
+  return (
+    <div className="border border-outline-variant bg-surface-container p-6">
+      <h3 className="font-sora text-sm font-bold uppercase tracking-[0.05em] text-on-surface mb-6">
+        APPLY FOR CAMPAIGN
+      </h3>
+
+      <div className="flex flex-col gap-5">
+        {/* Portfolio Link */}
+        <div>
+          <label className="text-[10px] font-semibold uppercase tracking-[0.05em] text-on-surface-variant mb-2 block">
+            PORTFOLIO LINK
+          </label>
+          <input
+            type="url"
+            placeholder="https://instagram.com/handle"
+            value={portfolioLink}
+            onChange={(e) => setPortfolioLink(e.target.value)}
+            className="w-full border border-outline-variant bg-surface-container-high px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant/50"
+          />
+        </div>
+
+        {/* Content Format */}
+        <div>
+          <label className="text-[10px] font-semibold uppercase tracking-[0.05em] text-on-surface-variant mb-2 block">
+            CONTENT FORMAT
+          </label>
+          <div className="relative">
+            <select
+              value={contentFormat}
+              onChange={(e) => setContentFormat(e.target.value)}
+              className="w-full border border-outline-variant bg-surface-container-high px-4 py-3 text-sm text-on-surface appearance-none"
+            >
+              {campaignDetailMock.contentFormats.map((format) => (
+                <option key={format} value={format}>
+                  {format}
+                </option>
+              ))}
+            </select>
+            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-on-surface-variant/50 pointer-events-none" />
+          </div>
+        </div>
+
+        {/* Pitch Message */}
+        <div>
+          <label className="text-[10px] font-semibold uppercase tracking-[0.05em] text-on-surface-variant mb-2 block">
+            PITCH MESSAGE
+          </label>
+          <textarea
+            placeholder="Why are you a good fit for this wearable launch?"
+            value={pitchMessage}
+            onChange={(e) => setPitchMessage(e.target.value)}
+            className="w-full border border-outline-variant bg-surface-container-high px-4 py-3 text-sm text-on-surface placeholder:text-on-surface-variant/50 min-h-[120px] resize-none"
+          />
+        </div>
+      </div>
+
+      <button
+        disabled
+        title="Coming soon"
+        className="w-full bg-primary-container text-on-primary py-4 font-bold text-sm tracking-wide hover:opacity-90 transition-opacity mt-2"
+      >
+        SUBMIT APPLICATION ▷
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/components/marketplace/campaign-brief-section.tsx
+++ b/apps/frontend/components/marketplace/campaign-brief-section.tsx
@@ -1,0 +1,39 @@
+import { Target, ClipboardCheck } from "lucide-react";
+import type { CampaignDetail } from "./campaign-detail-data";
+
+export function CampaignBriefSection({
+  campaign,
+}: {
+  campaign: CampaignDetail;
+}) {
+  return (
+    <section>
+      <h2 className="font-sora text-base font-semibold text-on-surface pb-3 border-b border-outline-variant">
+        Campaign Brief
+      </h2>
+      <p className="text-sm leading-relaxed text-on-surface-variant mt-4">
+        {campaign.brief}
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6">
+        <div className="border border-outline-variant bg-surface-container p-5">
+          <Target className="size-6 text-primary-container mb-3" />
+          <h3 className="text-sm font-semibold text-on-surface mb-2">
+            Target Audience
+          </h3>
+          <p className="text-xs leading-relaxed text-on-surface-variant">
+            {campaign.targetAudience}
+          </p>
+        </div>
+        <div className="border border-outline-variant bg-surface-container p-5">
+          <ClipboardCheck className="size-6 text-primary-container mb-3" />
+          <h3 className="text-sm font-semibold text-on-surface mb-2">
+            Deliverables
+          </h3>
+          <p className="text-xs leading-relaxed text-on-surface-variant">
+            {campaign.deliverables}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/marketplace/campaign-detail-data.ts
+++ b/apps/frontend/components/marketplace/campaign-detail-data.ts
@@ -1,0 +1,51 @@
+export type CampaignDetail = {
+  id: string;
+  title: string;
+  brand: string;
+  brandIconPath: string;
+  category: string;
+  heroImagePath: string;
+  brief: string;
+  targetAudience: string;
+  deliverables: string;
+  requirements: string[];
+  budget: string;
+  currency: string;
+  fundsLocked: string;
+  smartContract: string;
+  smartContractUrl: string;
+  payoutSchedule: string;
+  contentFormats: string[];
+};
+
+export const campaignDetailMock: CampaignDetail = {
+  id: "quantum-wearables",
+  title: "Quantum Wearables: Summer Launch",
+  brand: "Stellar Labs Inc.",
+  brandIconPath: "/images/brand-icon-placeholder.png",
+  category: "TECH & LIFESTYLE",
+  heroImagePath: "/images/campaign-hero-placeholder.png",
+  brief:
+    "We are launching the next generation of biometric integration. We're looking for professional creators who can blend technical performance with lifestyle aesthetics. Your content should highlight the seamless integration of our SDK into the daily life of a high-performance individual.",
+  targetAudience:
+    "Tech Enthusiasts, Professional Athletes, and Bio-hackers aged 24-45.",
+  deliverables:
+    "1x Long-form Video Review, 3x High-res Photography Posts, 2x Story Sequences.",
+  requirements: [
+    "Minimum 50k following on YouTube or Instagram.",
+    "History of tech-focused or lifestyle-performance content.",
+    "Located in Tier-1 markets (US, UK, EU, CAN).",
+  ],
+  budget: "$4,500.00",
+  currency: "USDC",
+  fundsLocked: "4,500.00  USDC",
+  smartContract: "Stellar::x4A...2fB",
+  smartContractUrl: "https://stellar.expert/explorer/testnet/contract/placeholder",
+  payoutSchedule: "50% Advance / 50% Final",
+  contentFormats: [
+    "Video Review (Primary)",
+    "Photography Posts",
+    "Instagram Stories",
+    "TikTok Short",
+  ],
+};

--- a/apps/frontend/components/marketplace/campaign-detail-header.tsx
+++ b/apps/frontend/components/marketplace/campaign-detail-header.tsx
@@ -1,0 +1,32 @@
+import { Briefcase } from "lucide-react";
+import type { CampaignDetail } from "./campaign-detail-data";
+
+export function CampaignDetailHeader({
+  campaign,
+}: {
+  campaign: CampaignDetail;
+}) {
+  return (
+    <div className="flex items-center gap-4">
+      <div className="size-12 border border-outline-variant bg-surface-container-high overflow-hidden flex items-center justify-center shrink-0">
+        {campaign.brandIconPath ? (
+          <img
+            src={campaign.brandIconPath}
+            alt={campaign.brand}
+            className="size-full object-cover"
+          />
+        ) : (
+          <Briefcase className="size-5 text-on-surface-variant" />
+        )}
+      </div>
+      <div>
+        <h1 className="font-sora text-lg font-semibold text-on-surface">
+          {campaign.title}
+        </h1>
+        <p className="text-sm text-on-surface-variant">
+          by {campaign.brand}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/marketplace/campaign-help-card.tsx
+++ b/apps/frontend/components/marketplace/campaign-help-card.tsx
@@ -1,0 +1,17 @@
+import { HelpCircle } from "lucide-react";
+
+export function CampaignHelpCard() {
+  return (
+    <div className="border border-outline-variant bg-surface-container p-5">
+      <div className="flex items-center gap-3">
+        <HelpCircle className="size-6 text-on-surface-variant shrink-0" />
+        <div>
+          <p className="text-sm font-semibold text-on-surface">Need Help?</p>
+          <p className="text-xs text-on-surface-variant">
+            Chat with a campaign manager
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/marketplace/campaign-hero-image.tsx
+++ b/apps/frontend/components/marketplace/campaign-hero-image.tsx
@@ -1,0 +1,24 @@
+import type { CampaignDetail } from "./campaign-detail-data";
+
+export function CampaignHeroImage({
+  campaign,
+}: {
+  campaign: CampaignDetail;
+}) {
+  return (
+    <div className="relative w-full overflow-hidden border border-outline-variant bg-surface-container">
+      {campaign.heroImagePath ? (
+        <img
+          src={campaign.heroImagePath}
+          alt={campaign.title}
+          className="aspect-[16/10] w-full object-cover bg-surface-container-high"
+        />
+      ) : (
+        <div className="aspect-[16/10] w-full bg-surface-container-high" />
+      )}
+      <div className="absolute top-4 left-4 border border-outline-variant bg-surface-container px-3 py-1.5 text-xs font-bold text-on-surface">
+        {campaign.category}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/marketplace/campaign-requirements.tsx
+++ b/apps/frontend/components/marketplace/campaign-requirements.tsx
@@ -1,0 +1,23 @@
+import { CheckCircle2 } from "lucide-react";
+
+export function CampaignRequirements({
+  requirements,
+}: {
+  requirements: string[];
+}) {
+  return (
+    <section>
+      <h2 className="font-sora text-base font-semibold text-on-surface pb-3 border-b border-outline-variant">
+        Requirements
+      </h2>
+      <div className="flex flex-col gap-3 mt-4">
+        {requirements.map((req, i) => (
+          <div key={i} className="flex items-start gap-3">
+            <CheckCircle2 className="size-5 shrink-0 text-primary-container mt-0.5" />
+            <span className="text-sm text-on-surface-variant">{req}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/marketplace/escrow-sidebar.tsx
+++ b/apps/frontend/components/marketplace/escrow-sidebar.tsx
@@ -1,0 +1,62 @@
+import { ShieldCheck } from "lucide-react";
+import type { CampaignDetail } from "./campaign-detail-data";
+
+export function EscrowSidebar({
+  campaign,
+}: {
+  campaign: CampaignDetail;
+}) {
+  return (
+    <div className="border border-outline-variant bg-surface-container p-6">
+      <div className="flex items-center justify-between">
+        <div className="border border-primary-container px-3 py-1 text-xs font-bold tracking-widest text-primary-container">
+          ESCROW VERIFIED
+        </div>
+        <div className="size-9 border border-outline-variant flex items-center justify-center">
+          <ShieldCheck className="size-5 text-primary-container" />
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <p className="font-sora text-[28px] font-bold text-on-surface">
+          {campaign.budget}
+        </p>
+        <p className="text-sm text-on-surface-variant mt-1">
+          Total Campaign Budget ({campaign.currency})
+        </p>
+      </div>
+
+      <div className="border-t border-outline-variant my-5" />
+
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-on-surface-variant">Funds Locked:</span>
+          <span className="text-sm font-semibold text-on-surface font-mono">
+            {campaign.fundsLocked}
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-on-surface-variant">
+            Smart Contract:
+          </span>
+          <a
+            href={campaign.smartContractUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-semibold text-primary-container hover:underline font-mono"
+          >
+            {campaign.smartContract}
+          </a>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-on-surface-variant">
+            Payout Schedule:
+          </span>
+          <span className="text-sm font-semibold text-on-surface">
+            {campaign.payoutSchedule}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/marketplace/marketplace-grid.tsx
+++ b/apps/frontend/components/marketplace/marketplace-grid.tsx
@@ -1,12 +1,14 @@
+import Link from "next/link";
 import { marketplaceCampaigns } from "./marketplace-data";
 
 export function MarketplaceGrid() {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
       {marketplaceCampaigns.map((campaign) => (
-        <div
+        <Link
           key={campaign.id}
-          className="border border-outline-variant bg-surface-container p-5"
+          href={`/marketplace/${campaign.id}`}
+          className="border border-outline-variant bg-surface-container p-5 block hover:border-primary-container transition-colors"
         >
           <p className="text-sm font-semibold text-on-surface">
             {campaign.title}
@@ -17,7 +19,7 @@ export function MarketplaceGrid() {
           <p className="mt-4 font-sora text-lg font-bold text-on-surface">
             {campaign.payout}
           </p>
-        </div>
+        </Link>
       ))}
     </div>
   );


### PR DESCRIPTION
closes #43 

All done. Here's a summary of what was implemented:

**Files created (9):**
- `campaign-detail-data.ts` — `CampaignDetail` type + mock data for "Quantum Wearables: Summer Launch"
- `campaign-detail-header.tsx` — brand icon placeholder + title + "by Stellar Labs Inc."
- `campaign-hero-image.tsx` — 16:10 hero image area with "TECH & LIFESTYLE" category badge overlay
- `campaign-brief-section.tsx` — full brief text + Target Audience & Deliverables info cards (Target/ClipboardCheck icons)
- `campaign-requirements.tsx` — 3 checklist items with lime `CheckCircle2` icons
- `escrow-sidebar.tsx` — "ESCROW VERIFIED" badge (lime border), $4,500.00 budget, funds locked, smart contract link, payout schedule
- `application-form.tsx` — `"use client"` with portfolio input, content format select, pitch textarea, disabled submit button
- `campaign-help-card.tsx` — "Need Help?" card with `HelpCircle` icon
- `[id]/page.tsx` — server component with Navbar/Footer, 12-col grid layout (7/5 split), responsive stacking

**Files modified (1):**
- `marketplace-grid.tsx` — each campaign card is now wrapped in `<Link href="/marketplace/[id]">` with hover border transition

**3 commits** on `feat/marketplace-campaign-detail`:
1. `feat_add_campaign_detail_data`
2. `feat_add_campaign_detail_components`
3. `feat_add_campaign_detail_page_and_wire_cards`

All components use the landing page token system (`bg-background`, `text-on-surface`, `border-outline-variant`, `bg-primary-container`), no `rounded` on outer containers, named exports, and no hardcoded hex values.