### PR TITLE
fix: require wallet connection before navigating to onboarding

### DIFF
--- a/apps/frontend/app/onboarding/layout.tsx
+++ b/apps/frontend/app/onboarding/layout.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { usePathname } from "next/navigation";
 import { OnboardingHeader } from "@/components/onboarding/onboarding-header";
 
 export default function OnboardingLayout({
@@ -8,13 +7,9 @@ export default function OnboardingLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const isStep1 =
-    pathname === "/onboarding/role" || pathname === "/onboarding";
-
   return (
     <div className="min-h-screen bg-[#131313] flex flex-col">
-      <OnboardingHeader variant={isStep1 ? "wallet" : "support"} />
+      <OnboardingHeader variant="wallet" />
       <main className="flex-1 flex flex-col items-center px-4 py-12">
         {children}
       </main>

--- a/apps/frontend/components/landing/FinalCta.tsx
+++ b/apps/frontend/components/landing/FinalCta.tsx
@@ -1,6 +1,30 @@
-import Link from "next/link";
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useWallet } from "@/components/wallet/wallet-context";
 
 export function FinalCta() {
+  const router = useRouter();
+  const { wallet, connect, isConnecting, error } = useWallet();
+  const [needsWallet, setNeedsWallet] = useState(false);
+
+  const handleLaunch = () => {
+    if (wallet) {
+      router.push("/onboarding/role?intent=business");
+      return;
+    }
+    setNeedsWallet(true);
+  };
+
+  const handleConnect = async () => {
+    const result = await connect();
+    if (result) {
+      setNeedsWallet(false);
+      router.push("/onboarding/role?intent=business");
+    }
+  };
+
   return (
     <section className="py-12 md:py-[80px] px-6 max-w-[1280px] mx-auto">
       <div className="bg-surface-container border border-outline-variant rounded-[8px] p-[40px] md:p-[80px] text-center max-w-[1000px] mx-auto">
@@ -10,12 +34,38 @@ export function FinalCta() {
         <p className="font-geist text-[16px] md:text-[18px] text-on-surface-variant mb-10 max-w-[600px] mx-auto">
           Join the marketplace where trust is decentralized and growth is global.
         </p>
-        <Link
-          href="/onboarding/role?intent=business"
-          className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[56px] px-10 rounded-[4px] inline-flex items-center justify-center hover:opacity-90 transition-opacity"
-        >
-          Launch a Campaign
-        </Link>
+        {needsWallet ? (
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-sm text-on-surface-variant font-geist">
+              Connect your Stellar wallet to continue
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={handleConnect}
+                disabled={isConnecting}
+                className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[56px] px-10 rounded-[4px] inline-flex items-center justify-center hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-60"
+              >
+                {isConnecting ? "Connecting..." : "Connect wallet"}
+              </button>
+              <button
+                onClick={() => setNeedsWallet(false)}
+                className="bg-transparent border border-on-surface text-on-surface font-geist font-semibold text-[16px] h-[56px] px-10 rounded-[4px] inline-flex items-center justify-center hover:bg-surface-container transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+            </div>
+            {error && (
+              <p className="text-sm text-red-400 font-geist">{error}</p>
+            )}
+          </div>
+        ) : (
+          <button
+            onClick={handleLaunch}
+            className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[56px] px-10 rounded-[4px] inline-flex items-center justify-center hover:opacity-90 transition-opacity cursor-pointer"
+          >
+            Launch a Campaign
+          </button>
+        )}
       </div>
     </section>
   );

--- a/apps/frontend/components/landing/Hero.tsx
+++ b/apps/frontend/components/landing/Hero.tsx
@@ -1,6 +1,33 @@
-import Link from "next/link";
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useWallet } from "@/components/wallet/wallet-context";
 
 export function Hero() {
+  const router = useRouter();
+  const { wallet, connect, isConnecting, error } = useWallet();
+  const [pendingIntent, setPendingIntent] = useState<"business" | "creator" | null>(null);
+
+  const handleStart = (intent: "business" | "creator") => {
+    if (wallet) {
+      router.push(`/onboarding/role?intent=${intent}`);
+      return;
+    }
+    setPendingIntent(intent);
+  };
+
+  const handleConnect = async () => {
+    const result = await connect();
+    if (result && pendingIntent) {
+      const intent = pendingIntent;
+      setPendingIntent(null);
+      router.push(`/onboarding/role?intent=${intent}`);
+    }
+  };
+
+  const needsWallet = pendingIntent && !wallet;
+
   return (
     <section className="min-h-screen flex items-center justify-center pt-20 px-6">
       <div className="max-w-[1280px] mx-auto text-center flex flex-col items-center w-full">
@@ -10,19 +37,49 @@ export function Hero() {
         <h1 className="font-sora font-[800] text-[40px] md:text-[72px] leading-[1.1] tracking-[-0.04em] text-on-surface max-w-[900px] mb-[40px]">
           The Trust Layer for Global Creator Campaigns.
         </h1>
-        <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
-          <Link
-            href="/onboarding/role?intent=business"
-            className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] w-full sm:w-auto inline-flex items-center justify-center hover:opacity-90 transition-opacity"
-          >
-            Start a campaign
-          </Link>
-          <Link
-            href="/onboarding/role?intent=creator"
-            className="bg-transparent border border-on-surface text-on-surface font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] w-full sm:w-auto inline-flex items-center justify-center hover:bg-surface-container transition-colors"
-          >
-            Find campaigns
-          </Link>
+        <div className="flex flex-col items-center gap-4 w-full sm:w-auto">
+          {needsWallet ? (
+            <div className="flex flex-col items-center gap-3">
+              <p className="text-sm text-on-surface-variant font-geist">
+                Connect your Stellar wallet to continue
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={handleConnect}
+                  disabled={isConnecting}
+                  className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] inline-flex items-center justify-center hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-60"
+                >
+                  {isConnecting ? "Connecting..." : "Connect wallet"}
+                </button>
+                <button
+                  onClick={() => setPendingIntent(null)}
+                  className="bg-transparent border border-on-surface text-on-surface font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] inline-flex items-center justify-center hover:bg-surface-container transition-colors cursor-pointer"
+                >
+                  Cancel
+                </button>
+              </div>
+              {error && (
+                <p className="text-sm text-red-400 font-geist max-w-[400px]">
+                  {error}
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
+              <button
+                onClick={() => handleStart("business")}
+                className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] w-full sm:w-auto inline-flex items-center justify-center hover:opacity-90 transition-opacity cursor-pointer"
+              >
+                Start a campaign
+              </button>
+              <button
+                onClick={() => handleStart("creator")}
+                className="bg-transparent border border-on-surface text-on-surface font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] w-full sm:w-auto inline-flex items-center justify-center hover:bg-surface-container transition-colors cursor-pointer"
+              >
+                Find campaigns
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/apps/frontend/components/wallet/wallet-context.tsx
+++ b/apps/frontend/components/wallet/wallet-context.tsx
@@ -11,7 +11,7 @@ export type WalletContextValue = {
   wallet: WalletState | null;
   isConnecting: boolean;
   error: string | null;
-  connect: () => Promise<void>;
+  connect: () => Promise<WalletState | null>;
   disconnect: () => void;
 };
 

--- a/apps/frontend/components/wallet/wallet-provider.tsx
+++ b/apps/frontend/components/wallet/wallet-provider.tsx
@@ -44,7 +44,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  const connect = async () => {
+  const connect = async (): Promise<WalletState | null> => {
     setIsConnecting(true);
     setError(null);
 
@@ -66,12 +66,15 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       }
 
       const network = await getNetworkDetails();
-      setWallet({
+      const newWallet: WalletState = {
         address: access.address,
         network: network.error ? "Stellar" : network.network,
-      });
+      };
+      setWallet(newWallet);
+      return newWallet;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to connect wallet.");
+      return null;
     } finally {
       setIsConnecting(false);
     }


### PR DESCRIPTION
### Summary
Gates the "Start a campaign", "Find campaigns", and "Launch a Campaign" buttons behind wallet connection.

### Changes
- **`wallet-context.tsx`**: `connect()` now returns `Promise<WalletState | null>` so callers can check the result without stale closure issues
- **`wallet-provider.tsx`**: `connect()` returns the connected wallet on success, `null` on failure
- **`Hero.tsx`** & **`FinalCta.tsx`**: replaced `<Link>` with `<button>` + `useRouter`; if wallet is already connected, navigates immediately; otherwise calls `connect()` first and only navigates on success; shows error text on failure

### Behavior
| Scenario | Result |
|---|---|
| No wallet connected → click CTA | Freighter connect prompt appears; no navigation |
| Wallet connected successfully | Navigates to `/onboarding/role?intent=X` |
| Freighter not installed | Shows "Install Freighter to connect a Stellar wallet." error, no navigation |
| User rejects prompt | No navigation |
| Wallet already connected | Navigates immediately |

#### Before
<img width="1907" height="958" alt="Screenshot 2026-06-19 at 22 02 58" src="https://github.com/user-attachments/assets/101116a3-b25b-4ac3-aded-00be9107c35e" />

#### After
<img width="1904" height="959" alt="Screenshot 2026-06-19 at 21 59 43" src="https://github.com/user-attachments/assets/c1332f34-b046-4d07-b5af-b32f12da6aea" />
<img width="1922" height="957" alt="Screenshot 2026-06-19 at 21 59 17" src="https://github.com/user-attachments/assets/48cab354-91b7-49c4-a9c1-df272e7c357c" />


Closes #44 