### PR TITLE
feat(dashboard): build creator analytics page

### DIFF
--- a/apps/frontend/app/dashboard/creator/analytics/page.tsx
+++ b/apps/frontend/app/dashboard/creator/analytics/page.tsx
@@ -1,32 +1,37 @@
-import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
+import {
+  analyticStats,
+  growthSeries,
+  ageGroups,
+  topLocations,
+  channels,
+  topCampaigns,
+} from "@/components/dashboard/creator/creator-analytics-data";
+import { AnalyticsPageHeader } from "@/components/dashboard/creator/analytics-page-header";
+import { AnalyticsStatCards } from "@/components/dashboard/creator/analytics-stat-cards";
+import { FollowerGrowthChart } from "@/components/dashboard/creator/follower-growth-chart";
+import { AgeDistributionPanel } from "@/components/dashboard/creator/age-distribution-panel";
+import { TopLocationsPanel } from "@/components/dashboard/creator/top-locations-panel";
+import { ChannelPerformanceSection } from "@/components/dashboard/creator/channel-performance-section";
+import { TopPerformingTable } from "@/components/dashboard/creator/top-performing-table";
 
-/**
- * Placeholder route. Full implementation tracked in
- * https://github.com/Ads-Bazaar/ads-bazaar/issues/50 — see that issue for the
- * file structure, components, design tokens, and acceptance criteria before
- * building this page out.
- */
 export default function CreatorAnalyticsPage() {
   return (
-    <>
-      <DashboardHeader eyebrow="Performance insights" title="Analytics & Insights" />
+    <div className="flex flex-col gap-6">
+      <AnalyticsPageHeader />
+      <AnalyticsStatCards stats={analyticStats} />
 
-      <div className="flex flex-col items-center justify-center gap-2 border border-[var(--dash-border)] bg-[var(--dash-surface)] px-6 py-20 text-center">
-        <p className="text-sm font-medium text-[var(--dash-heading)]">
-          This page is under construction.
-        </p>
-        <p className="max-w-md text-sm text-[var(--dash-muted)]">
-          Full implementation is tracked in{" "}
-          <a
-            href="https://github.com/Ads-Bazaar/ads-bazaar/issues/50"
-            className="text-[var(--dash-accent)] hover:underline"
-          >
-            Issue #50
-          </a>
-          . Replace this file according to that spec — do not add a sidebar or
-          layout wrapper, the creator dashboard shell already provides it.
-        </p>
+      <div className="grid grid-cols-12 gap-6">
+        <div className="col-span-12 lg:col-span-8">
+          <FollowerGrowthChart series={growthSeries} />
+        </div>
+        <div className="col-span-12 flex flex-col gap-6 lg:col-span-4">
+          <AgeDistributionPanel groups={ageGroups} />
+          <TopLocationsPanel locations={topLocations} />
+        </div>
       </div>
-    </>
+
+      <ChannelPerformanceSection channels={channels} />
+      <TopPerformingTable campaigns={topCampaigns} />
+    </div>
   );
 }

--- a/apps/frontend/app/dashboard/creator/analytics/page.tsx
+++ b/apps/frontend/app/dashboard/creator/analytics/page.tsx
@@ -1,11 +1,5 @@
-import {
-  analyticStats,
-  growthSeries,
-  ageGroups,
-  topLocations,
-  channels,
-  topCampaigns,
-} from "@/components/dashboard/creator/creator-analytics-data";
+import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
+import { analyticStats, growthSeries, ageGroups, topLocations, channels, topCampaigns } from "@/components/dashboard/creator/creator-analytics-data";
 import { AnalyticsPageHeader } from "@/components/dashboard/creator/analytics-page-header";
 import { AnalyticsStatCards } from "@/components/dashboard/creator/analytics-stat-cards";
 import { FollowerGrowthChart } from "@/components/dashboard/creator/follower-growth-chart";
@@ -16,7 +10,9 @@ import { TopPerformingTable } from "@/components/dashboard/creator/top-performin
 
 export default function CreatorAnalyticsPage() {
   return (
-    <div className="flex flex-col gap-6">
+    <>
+      <DashboardHeader eyebrow="Performance insights" title="Analytics & Insights" />
+      <div className="flex flex-col gap-6">
       <AnalyticsPageHeader />
       <AnalyticsStatCards stats={analyticStats} />
 
@@ -33,5 +29,6 @@ export default function CreatorAnalyticsPage() {
       <ChannelPerformanceSection channels={channels} />
       <TopPerformingTable campaigns={topCampaigns} />
     </div>
+    </>
   );
 }

--- a/apps/frontend/components/dashboard/creator/age-distribution-panel.tsx
+++ b/apps/frontend/components/dashboard/creator/age-distribution-panel.tsx
@@ -1,0 +1,29 @@
+import type { AgeGroup } from "./creator-analytics-data";
+
+export function AgeDistributionPanel({ groups }: { groups: AgeGroup[] }) {
+  return (
+    <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-5">
+      <p className="mb-4 text-sm font-semibold text-[var(--dash-heading)]">Age Distribution</p>
+      <div className="flex flex-col gap-4">
+        {groups.map((group) => (
+          <div key={group.label} className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold text-[var(--dash-heading)]">
+                {group.label}
+              </span>
+              <span className="text-xs font-bold text-[var(--dash-heading)]">
+                {group.percentage}%
+              </span>
+            </div>
+            <div className="h-2 w-full bg-[var(--dash-border)]">
+              <div
+                className="h-full rounded bg-[var(--dash-accent)]"
+                style={{ width: `${group.percentage}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/analytics-page-header.tsx
+++ b/apps/frontend/components/dashboard/creator/analytics-page-header.tsx
@@ -1,0 +1,37 @@
+import { Calendar, ChevronDown, Download } from "lucide-react";
+
+export function AnalyticsPageHeader() {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h1 className="font-[family-name:var(--font-sora)] text-[28px] font-semibold text-[var(--dash-heading)]">
+          Analytics &amp; Insights
+        </h1>
+        <p className="mt-1 text-sm text-[var(--dash-muted)]">
+          Real-time performance metrics across your connected social channels.
+        </p>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          disabled
+          title="Coming soon"
+          className="flex items-center gap-2 border-2 border-[var(--dash-border)] bg-[var(--dash-surface)] px-4 py-2 text-sm text-[var(--dash-body)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <Calendar className="size-4" aria-hidden="true" />
+          Last 30 Days
+          <ChevronDown className="size-4" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          disabled
+          title="Coming soon"
+          className="flex items-center gap-2 border-2 border-[var(--dash-border)] bg-[var(--dash-surface)] px-4 py-2 text-sm font-semibold text-[var(--dash-heading)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <Download className="size-4" aria-hidden="true" />
+          Export
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/analytics-stat-cards.tsx
+++ b/apps/frontend/components/dashboard/creator/analytics-stat-cards.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { TrendingUp, TrendingDown, Users, Zap, Tv, ShieldCheck } from "lucide-react";
+import type { AnalyticStat } from "./creator-analytics-data";
+
+const iconMap = {
+  users: Users,
+  zap: Zap,
+  tv: Tv,
+  "shield-check": ShieldCheck,
+} as const;
+
+function StatCard({ stat }: { stat: AnalyticStat }) {
+  const Icon = iconMap[stat.iconId];
+  const { positive, value: deltaValue } = stat.delta;
+
+  return (
+    <article className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-5">
+      <div className="flex items-start justify-between">
+        <div className="flex size-9 items-center justify-center border border-[var(--dash-border)] bg-[var(--dash-bg)]">
+          <Icon className="size-4 text-[var(--dash-accent-strong)]" aria-hidden="true" />
+        </div>
+        <span
+          className={`flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[10px] font-bold ${
+            positive
+              ? "bg-[color-mix(in_srgb,var(--dash-accent-strong)_20%,transparent)] text-[var(--dash-accent-strong)]"
+              : "bg-red-400/10 text-red-400"
+          }`}
+        >
+          {positive ? (
+            <TrendingUp className="size-2.5" aria-hidden="true" />
+          ) : (
+            <TrendingDown className="size-2.5" aria-hidden="true" />
+          )}
+          {deltaValue}
+        </span>
+      </div>
+      <p className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--dash-muted)]">
+        {stat.label}
+      </p>
+      <p className="mt-0.5 font-[family-name:var(--font-sora)] text-[22px] font-semibold text-[var(--dash-heading)]">
+        {stat.value}
+      </p>
+    </article>
+  );
+}
+
+export function AnalyticsStatCards({ stats }: { stats: AnalyticStat[] }) {
+  return (
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      {stats.map((stat) => (
+        <StatCard key={stat.id} stat={stat} />
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/channel-performance-section.tsx
+++ b/apps/frontend/components/dashboard/creator/channel-performance-section.tsx
@@ -1,0 +1,62 @@
+import Image from "next/image";
+import type { ChannelCard } from "./creator-analytics-data";
+
+function ChannelCardItem({ channel }: { channel: ChannelCard }) {
+  const barEntries: { key: "views" | "likes" | "shares"; label: string }[] = [
+    { key: "views", label: "VIEWS" },
+    { key: "likes", label: "LIKES" },
+    { key: "shares", label: "SHARES" },
+  ];
+
+  return (
+    <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-5">
+      <div className="mb-6 flex items-center gap-3">
+        <Image
+          src={channel.iconPath}
+          alt={channel.name}
+          width={32}
+          height={32}
+          className="size-8"
+        />
+        <span className="text-sm font-bold text-[var(--dash-heading)]">{channel.name}</span>
+      </div>
+
+      <div className="flex h-20 items-end justify-around gap-3">
+        {barEntries.map(({ key }) => (
+          <div key={key} className="relative flex h-full w-6 items-end bg-[var(--dash-border)]">
+            <div
+              className="w-full rounded bg-[var(--dash-accent)]"
+              style={{ height: `${channel.bars[key]}%` }}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-2 flex justify-around">
+        {barEntries.map(({ key, label }) => (
+          <span key={key} className="text-[10px] font-semibold uppercase text-[var(--dash-muted)]">
+            {label}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between border-t border-[var(--dash-border)] pt-4">
+        <span className="text-xs text-[var(--dash-muted)]">Conversion Rate</span>
+        <span className="text-sm font-bold text-[var(--dash-accent)]">{channel.conversionRate}</span>
+      </div>
+    </div>
+  );
+}
+
+export function ChannelPerformanceSection({ channels }: { channels: ChannelCard[] }) {
+  return (
+    <div>
+      <p className="mb-4 text-sm font-semibold text-[var(--dash-heading)]">Channel Performance</p>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {channels.map((channel) => (
+          <ChannelCardItem key={channel.id} channel={channel} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/creator-analytics-data.ts
+++ b/apps/frontend/components/dashboard/creator/creator-analytics-data.ts
@@ -1,0 +1,84 @@
+export type StatDelta = { value: string; positive: boolean };
+
+export type AnalyticStat = {
+  id: string;
+  label: string;
+  value: string;
+  delta: StatDelta;
+  iconId: "users" | "zap" | "tv" | "shield-check";
+};
+
+export type GrowthPoint = {
+  label: string;
+  growth: number;
+  engagement: number;
+};
+
+export type AgeGroup = {
+  label: string;
+  percentage: number;
+};
+
+export type LocationRow = {
+  rank: string;
+  name: string;
+  percentage: string;
+};
+
+export type ChannelCard = {
+  id: string;
+  name: string;
+  iconPath: string;
+  bars: { views: number; likes: number; shares: number };
+  conversionRate: string;
+};
+
+export type TopCampaign = {
+  id: string;
+  title: string;
+  date: string;
+  thumbnailPath: string;
+  platform: string;
+  totalReach: string;
+  engagement: string;
+  roi: string;
+};
+
+export const analyticStats: AnalyticStat[] = [
+  { id: "reach", label: "TOTAL REACH", value: "1,248,500", delta: { value: "+12.4%", positive: true }, iconId: "users" },
+  { id: "engagement", label: "ENGAGEMENT RATE", value: "4.82%", delta: { value: "+5.2%", positive: true }, iconId: "zap" },
+  { id: "payout", label: "AVG. PAYOUT", value: "$3,420", delta: { value: "-1.1%", positive: false }, iconId: "tv" },
+  { id: "success", label: "CAMPAIGN SUCCESS", value: "98.5%", delta: { value: "+2.0%", positive: true }, iconId: "shield-check" },
+];
+
+export const growthSeries: GrowthPoint[] = [
+  { label: "MAY 01", growth: 15, engagement: 10 },
+  { label: "MAY 08", growth: 25, engagement: 18 },
+  { label: "MAY 15", growth: 40, engagement: 30 },
+  { label: "MAY 22", growth: 55, engagement: 35 },
+  { label: "MAY 30", growth: 80, engagement: 60 },
+];
+
+export const ageGroups: AgeGroup[] = [
+  { label: "18-24", percentage: 42 },
+  { label: "25-34", percentage: 35 },
+  { label: "35-44", percentage: 18 },
+];
+
+export const topLocations: LocationRow[] = [
+  { rank: "01", name: "United States", percentage: "48%" },
+  { rank: "02", name: "United Kingdom", percentage: "12%" },
+  { rank: "03", name: "Germany", percentage: "9%" },
+];
+
+export const channels: ChannelCard[] = [
+  { id: "instagram", name: "Instagram", iconPath: "/icons/instagram.svg", bars: { views: 70, likes: 50, shares: 30 }, conversionRate: "3.2%" },
+  { id: "tiktok", name: "TikTok", iconPath: "/icons/tiktok.svg", bars: { views: 85, likes: 65, shares: 45 }, conversionRate: "5.8%" },
+  { id: "youtube", name: "YouTube", iconPath: "/icons/youtube.svg", bars: { views: 55, likes: 40, shares: 20 }, conversionRate: "2.4%" },
+];
+
+export const topCampaigns: TopCampaign[] = [
+  { id: "stellar-wallet", title: "Stellar Wallet: Future of FinTech", date: "May 14, 2024", thumbnailPath: "/images/thumb-stellar.jpg", platform: "Instagram Reels", totalReach: "452,000", engagement: "8.4%", roi: "4.2x" },
+  { id: "luxefit", title: "LuxeFit: Summer 24 Drop", date: "May 08, 2024", thumbnailPath: "/images/thumb-luxefit.jpg", platform: "TikTok", totalReach: "892,400", engagement: "12.1%", roi: "6.8x" },
+  { id: "saas-flow", title: "SaaS Flow: Productivity Hack", date: "May 02, 2024", thumbnailPath: "/images/thumb-saas.jpg", platform: "YouTube Short", totalReach: "125,300", engagement: "5.2%", roi: "3.1x" },
+];

--- a/apps/frontend/components/dashboard/creator/follower-growth-chart.tsx
+++ b/apps/frontend/components/dashboard/creator/follower-growth-chart.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { GrowthPoint } from "./creator-analytics-data";
+
+function smoothPath(points: { x: number; y: number }[]): string {
+  if (points.length < 2) return "";
+  let d = `M ${points[0].x} ${points[0].y}`;
+  for (let i = 0; i < points.length - 1; i++) {
+    const p0 = points[i];
+    const p1 = points[i + 1];
+    const dx = (p1.x - p0.x) * 0.4;
+    d += ` C ${p0.x + dx} ${p0.y}, ${p1.x - dx} ${p1.y}, ${p1.x} ${p1.y}`;
+  }
+  return d;
+}
+
+function smoothArea(points: { x: number; y: number }[], bottomY: number): string {
+  if (points.length < 2) return "";
+  const line = smoothPath(points);
+  const last = points[points.length - 1];
+  const first = points[0];
+  return `${line} L ${last.x} ${bottomY} L ${first.x} ${bottomY} Z`;
+}
+
+export function FollowerGrowthChart({ series }: { series: GrowthPoint[] }) {
+  const W = 500;
+  const H = 200;
+  const PAD = { top: 10, right: 10, bottom: 10, left: 10 };
+  const innerW = W - PAD.left - PAD.right;
+  const innerH = H - PAD.top - PAD.bottom;
+
+  const maxVal = Math.max(...series.map((p) => Math.max(p.growth, p.engagement)), 1);
+
+  const toPoint = (value: number, index: number) => ({
+    x: PAD.left + (index / (series.length - 1)) * innerW,
+    y: PAD.top + innerH - (value / maxVal) * innerH,
+  });
+
+  const growthPoints = series.map((p, i) => toPoint(p.growth, i));
+  const engagementPoints = series.map((p, i) => toPoint(p.engagement, i));
+  const bottomY = PAD.top + innerH;
+
+  return (
+    <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-6">
+      <div className="mb-4 flex items-start justify-between">
+        <div>
+          <p className="text-sm font-semibold text-[var(--dash-heading)]">
+            Follower Growth &amp; Engagement
+          </p>
+          <p className="mt-0.5 text-xs text-[var(--dash-muted)]">
+            Activity tracked from May 1st to May 30th
+          </p>
+        </div>
+        <div className="flex gap-4">
+          <span className="flex items-center gap-1.5 text-xs text-[var(--dash-muted)]">
+            <span className="size-2 rounded-full bg-[var(--dash-accent)]" />
+            Growth
+          </span>
+          <span className="flex items-center gap-1.5 text-xs text-[var(--dash-muted)]">
+            <span className="size-2 rounded-full bg-white/50" />
+            Engagement
+          </span>
+        </div>
+      </div>
+
+      <div className="relative mt-4 h-60">
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          preserveAspectRatio="none"
+          className="h-full w-full"
+          aria-hidden="true"
+        >
+          <defs>
+            <linearGradient id="growthFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--dash-accent)" stopOpacity="0.4" />
+              <stop offset="95%" stopColor="var(--dash-accent)" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+          {growthPoints.map((p, i) => (
+            <line
+              key={series[i].label}
+              x1={p.x}
+              y1={PAD.top}
+              x2={p.x}
+              y2={bottomY}
+              stroke="var(--dash-border)"
+              strokeWidth={0.8}
+              strokeOpacity={0.7}
+            />
+          ))}
+          <path d={smoothArea(growthPoints, bottomY)} fill="url(#growthFill)" />
+          <path
+            d={smoothPath(growthPoints)}
+            fill="none"
+            stroke="var(--dash-accent)"
+            strokeWidth={2}
+          />
+          <path
+            d={smoothPath(engagementPoints)}
+            fill="none"
+            stroke="white"
+            strokeWidth={1.5}
+            strokeOpacity={0.5}
+            strokeDasharray="4 4"
+          />
+        </svg>
+      </div>
+
+      <div className="mt-3 flex justify-between">
+        {series.map((p) => (
+          <span key={p.label} className="text-[10px] text-[var(--dash-muted)]">
+            {p.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/top-locations-panel.tsx
+++ b/apps/frontend/components/dashboard/creator/top-locations-panel.tsx
@@ -1,0 +1,20 @@
+import type { LocationRow } from "./creator-analytics-data";
+
+export function TopLocationsPanel({ locations }: { locations: LocationRow[] }) {
+  return (
+    <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-5">
+      <p className="mb-4 text-sm font-semibold text-[var(--dash-heading)]">Top Locations</p>
+      <div className="flex flex-col gap-3">
+        {locations.map((loc) => (
+          <div key={loc.rank} className="flex items-center gap-3">
+            <span className="w-6 shrink-0 text-xs font-bold text-[var(--dash-muted)]">
+              {loc.rank}
+            </span>
+            <span className="flex-1 text-sm text-[var(--dash-heading)]">{loc.name}</span>
+            <span className="text-sm font-bold text-[var(--dash-accent)]">{loc.percentage}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/creator/top-performing-table.tsx
+++ b/apps/frontend/components/dashboard/creator/top-performing-table.tsx
@@ -1,0 +1,83 @@
+import { MoreVertical } from "lucide-react";
+import type { TopCampaign } from "./creator-analytics-data";
+
+export function TopPerformingTable({ campaigns }: { campaigns: TopCampaign[] }) {
+  return (
+    <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)]">
+      <div className="flex items-center justify-between border-b border-[var(--dash-border)] px-6 py-4">
+        <p className="text-sm font-semibold text-[var(--dash-heading)]">Top Performing Campaigns</p>
+        <a
+          href="#"
+          className="pointer-events-none text-xs font-bold text-[var(--dash-accent)] hover:underline"
+          aria-disabled="true"
+          tabIndex={-1}
+        >
+          View All Submissions →
+        </a>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[640px] border-collapse text-left">
+          <thead>
+            <tr>
+              {["CAMPAIGN CONTENT", "PLATFORM", "TOTAL REACH", "ENGAGEMENT", "ROI (EST.)", ""].map(
+                (col) => (
+                  <th
+                    key={col}
+                    className="px-6 py-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--dash-muted)]"
+                  >
+                    {col}
+                  </th>
+                ),
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[var(--dash-border)]">
+            {campaigns.map((campaign) => (
+              <tr
+                key={campaign.id}
+                className="transition-colors hover:bg-[var(--dash-bg)]"
+              >
+                <td className="px-6 py-4">
+                  <div className="flex items-center gap-3">
+                    <div className="size-10 shrink-0 bg-[var(--dash-bg)]" />
+                    <div>
+                      <p className="text-sm font-semibold text-[var(--dash-heading)]">
+                        {campaign.title}
+                      </p>
+                      <p className="text-xs text-[var(--dash-muted)]">{campaign.date}</p>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-6 py-4">
+                  <span className="border border-[var(--dash-border)] px-2 py-0.5 text-xs text-[var(--dash-body)]">
+                    {campaign.platform}
+                  </span>
+                </td>
+                <td className="px-6 py-4 text-sm text-[var(--dash-heading)]">
+                  {campaign.totalReach}
+                </td>
+                <td className="px-6 py-4 text-sm text-[var(--dash-body)]">
+                  {campaign.engagement}
+                </td>
+                <td className="px-6 py-4 text-sm font-bold text-[var(--dash-accent)]">
+                  {campaign.roi}
+                </td>
+                <td className="px-6 py-4">
+                  <button
+                    type="button"
+                    disabled
+                    title="Coming soon"
+                    className="disabled:cursor-not-allowed"
+                  >
+                    <MoreVertical className="size-4 text-[var(--dash-muted)]" aria-hidden="true" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Replace creator analytics stub with full implementation.

- Add 4 stat cards: Total Reach, Engagement Rate, Avg. Payout, Campaign Success
- Add FollowerGrowthChart with growth/engagement lines (client component)
- Add Age Distribution and Top Locations panels with lime bar fills
- Add Channel Performance cards for Instagram, TikTok, YouTube w/ mini charts
- Add Top Performing Campaigns table with horizontal scroll on mobile
- Resolve platform icons via iconId + iconMap to keep LucideIcon off the server/client boundary
- Use --dash-* tokens only, no hardcoded hex; no rounded on outer containers

Closes #50