### PR TITLE
feat: Build Explore Page — Trending Campaigns, Market Insights & Top Creators

### DIFF
--- a/apps/frontend/app/explore/page.tsx
+++ b/apps/frontend/app/explore/page.tsx
@@ -1,0 +1,29 @@
+import { Navbar } from "@/components/landing/Navbar";
+import { Footer } from "@/components/landing/Footer";
+import { ExploreHero } from "@/components/explore/explore-hero";
+import { TrendingCampaigns } from "@/components/explore/trending-campaigns";
+import { MarketInsights } from "@/components/explore/market-insights";
+import { TopCreators } from "@/components/explore/top-creators";
+
+export const metadata = {
+  title: "Explore — AdsBazaar",
+  description:
+    "Discover trending campaigns, market insights, and top-rated creators across the AdsBazaar ecosystem.",
+};
+
+export default function ExplorePage() {
+  return (
+    <>
+      <Navbar />
+      <main className="max-w-[1280px] mx-auto px-6 lg:px-10 pt-28 pb-20">
+        <ExploreHero />
+        <TrendingCampaigns />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-12">
+          <MarketInsights />
+          <TopCreators />
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/frontend/components/explore/creator-avatar.tsx
+++ b/apps/frontend/components/explore/creator-avatar.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import type { CreatorCard } from "./explore-data";
+
+// Avatar images may not exist at the given paths yet — gracefully fall back to
+// the creator's initials on a dark circle so cards always render cleanly.
+export function CreatorAvatar({ creator }: { creator: CreatorCard }) {
+  const [failed, setFailed] = useState(false);
+
+  const initials = creator.name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="size-12 rounded-full bg-surface-container overflow-hidden shrink-0 flex items-center justify-center">
+      {failed ? (
+        <span className="text-xs font-bold text-on-surface-variant">
+          {initials}
+        </span>
+      ) : (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={creator.avatarPath}
+          alt={creator.name}
+          className="size-full object-cover"
+          onError={() => setFailed(true)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/explore/explore-data.ts
+++ b/apps/frontend/components/explore/explore-data.ts
@@ -1,0 +1,131 @@
+export type TrendingCampaignTag = "hot" | "featured";
+
+export type TrendingCampaignItem = {
+  id: string;
+  title: string;
+  description: string;
+  budget: string;
+  tag: TrendingCampaignTag | null;
+  iconBg: string; // Tailwind bg class for the icon box
+};
+
+export type InsightRow = {
+  id: string;
+  title: string;
+  subtitle: string;
+  delta: string;
+  period: string;
+};
+
+export type CreatorCard = {
+  id: string;
+  name: string;
+  specialty: string;
+  reach: string;
+  rating: string;
+  avatarPath: string;
+};
+
+export const hashtagPills = [
+  "#StellarSummer",
+  "#Web3Gaming",
+  "#FintechReach",
+  "#CreatorEconomy",
+  "#DeFiSocial",
+];
+
+export const trendingCampaigns: TrendingCampaignItem[] = [
+  {
+    id: "nebula-wallet",
+    title: "Nebula Wallet Launch",
+    description:
+      "Promote the first decentralized yield aggregator on Stellar with native Soroban integration.",
+    budget: "12.5k XLM",
+    tag: "hot",
+    iconBg: "bg-blue-900/40",
+  },
+  {
+    id: "galactic-arena",
+    title: "Galactic Arena Alpha",
+    description:
+      "Top-tier gaming creators needed for the largest RPG tournament on the Stellar network.",
+    budget: "50.0k XLM",
+    tag: "featured",
+    iconBg: "bg-red-900/40",
+  },
+  {
+    id: "eco-friendly",
+    title: "Eco-Friendly Blockchain",
+    description:
+      "Educational series about Stellar energy consumption and sustainable validation.",
+    budget: "8.2k XLM",
+    tag: null,
+    iconBg: "bg-green-900/40",
+  },
+];
+
+export const insightRows: InsightRow[] = [
+  {
+    id: "latam",
+    title: "LatAm Fintech",
+    subtitle: "Payment adoption growth",
+    delta: "+24.8%",
+    period: "THIS MONTH",
+  },
+  {
+    id: "web3",
+    title: "Web3 Gaming",
+    subtitle: "Active wallet engagement",
+    delta: "+18.2%",
+    period: "THIS MONTH",
+  },
+  {
+    id: "defi",
+    title: "DeFi Education",
+    subtitle: "Tutorial content demand",
+    delta: "+12.5%",
+    period: "THIS MONTH",
+  },
+];
+
+export const payoutTrend = {
+  label: "PAYOUT TREND",
+  text: "Average campaign payout increased by",
+  highlight: "14%",
+  suffix: "across the Stellar network since the Soroban mainnet launch.",
+};
+
+export const topCreators: CreatorCard[] = [
+  {
+    id: "alex",
+    name: "Alex Rivera",
+    specialty: "Fintech & Macro",
+    reach: "1.2M",
+    rating: "4.8",
+    avatarPath: "/images/creator-alex.jpg",
+  },
+  {
+    id: "sarah",
+    name: "Sarah Chen",
+    specialty: "Web3 Gaming",
+    reach: "850K",
+    rating: "4.9",
+    avatarPath: "/images/creator-sarah.jpg",
+  },
+  {
+    id: "marcus",
+    name: "Marcus Thorne",
+    specialty: "Developer Advocacy",
+    reach: "420K",
+    rating: "5.0",
+    avatarPath: "/images/creator-marcus.jpg",
+  },
+  {
+    id: "elena",
+    name: "Elena Vance",
+    specialty: "Brand Strategy",
+    reach: "2.1M",
+    rating: "4.7",
+    avatarPath: "/images/creator-elena.jpg",
+  },
+];

--- a/apps/frontend/components/explore/explore-hero.tsx
+++ b/apps/frontend/components/explore/explore-hero.tsx
@@ -1,0 +1,22 @@
+import { hashtagPills } from "./explore-data";
+
+export function ExploreHero() {
+  return (
+    <section>
+      <h1 className="font-sora text-[48px] lg:text-[64px] font-[900] italic text-on-surface text-center leading-[1.05] max-w-[700px] mx-auto">
+        Discover the Next Big Growth Opportunity
+      </h1>
+      <div className="flex flex-wrap justify-center gap-3 mt-8">
+        {hashtagPills.map((pill) => (
+          <button
+            key={pill}
+            type="button"
+            className="border border-outline-variant bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant hover:border-primary-container hover:text-primary-container transition-colors cursor-pointer"
+          >
+            {pill}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/explore/market-insights.tsx
+++ b/apps/frontend/components/explore/market-insights.tsx
@@ -1,0 +1,49 @@
+import { insightRows, payoutTrend } from "./explore-data";
+
+export function MarketInsights() {
+  return (
+    <section className="border border-outline-variant bg-surface-container p-6">
+      <h2 className="font-sora text-xl font-bold text-on-surface mb-6">
+        Market Insights
+      </h2>
+
+      <div className="flex flex-col gap-3">
+        {insightRows.map((row) => (
+          <div
+            key={row.id}
+            className="border border-outline-variant bg-surface-container-high px-5 py-4 flex items-center justify-between"
+          >
+            <div>
+              <p className="text-sm font-semibold text-on-surface">{row.title}</p>
+              <p className="text-xs text-on-surface-variant mt-0.5">
+                {row.subtitle}
+              </p>
+            </div>
+            <div className="text-right">
+              <p className="text-lg font-bold text-primary-container">
+                {row.delta}
+              </p>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.05em] text-on-surface-variant">
+                {row.period}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Payout trend callout */}
+      <div className="mt-4 border border-primary-container/30 bg-surface-container-high p-5">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.05em] text-primary-container mb-2">
+          {payoutTrend.label}
+        </p>
+        <p className="text-sm leading-relaxed text-on-surface-variant">
+          {payoutTrend.text}{" "}
+          <span className="font-bold italic text-on-surface">
+            {payoutTrend.highlight}
+          </span>{" "}
+          {payoutTrend.suffix}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/explore/top-creators.tsx
+++ b/apps/frontend/components/explore/top-creators.tsx
@@ -1,0 +1,59 @@
+import { SlidersHorizontal } from "lucide-react";
+import { topCreators } from "./explore-data";
+import { CreatorAvatar } from "./creator-avatar";
+
+export function TopCreators() {
+  return (
+    <section className="border border-outline-variant bg-surface-container p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="font-sora text-xl font-bold text-on-surface">
+          Top Rated Creators
+        </h2>
+        <SlidersHorizontal className="size-5 text-on-surface-variant" />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {topCreators.map((creator) => (
+          <div
+            key={creator.id}
+            className="border border-outline-variant bg-surface-container-high p-4 flex items-center gap-3"
+          >
+            <CreatorAvatar creator={creator} />
+            <div>
+              <p className="text-sm font-semibold text-on-surface">
+                {creator.name}
+              </p>
+              <p className="text-xs text-on-surface-variant">
+                {creator.specialty}
+              </p>
+              <div className="flex items-center gap-3 mt-1">
+                <span className="text-xs font-bold text-primary-container">
+                  {creator.reach}
+                  <span className="text-[10px] text-on-surface-variant ml-0.5">
+                    REACH
+                  </span>
+                </span>
+                <span className="text-on-surface-variant opacity-30">•</span>
+                <span className="text-xs font-bold text-on-surface">
+                  {creator.rating}
+                  <span className="text-[10px] text-on-surface-variant ml-0.5">
+                    RATING
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        disabled
+        title="Coming soon"
+        className="mt-4 w-full border border-outline-variant py-3 text-center text-sm font-semibold text-on-surface-variant hover:text-on-surface hover:border-primary-container transition-colors cursor-pointer"
+      >
+        Discover More Creators
+      </button>
+    </section>
+  );
+}

--- a/apps/frontend/components/explore/trending-campaign-card.tsx
+++ b/apps/frontend/components/explore/trending-campaign-card.tsx
@@ -1,0 +1,67 @@
+import { ArrowUpRight, Briefcase, Plus } from "lucide-react";
+import type { TrendingCampaignItem } from "./explore-data";
+
+export function TrendingCampaignCard({
+  campaign,
+}: {
+  campaign: TrendingCampaignItem;
+}) {
+  const isFeatured = campaign.tag === "featured";
+
+  return (
+    <article
+      className={`border border-outline-variant p-5 flex flex-col h-full ${
+        isFeatured
+          ? "bg-primary-container text-on-primary"
+          : "bg-surface-container text-on-surface"
+      }`}
+    >
+      {/* Header: icon box + optional tag badge */}
+      <div className="flex items-start justify-between mb-4">
+        <div
+          className={`size-12 flex items-center justify-center ${campaign.iconBg}`}
+        >
+          <Briefcase className="size-6" />
+        </div>
+
+        {campaign.tag === "hot" && (
+          <span className="rounded border px-2 py-0.5 text-[10px] font-bold tracking-widest border-red-400 text-red-400">
+            HOT
+          </span>
+        )}
+        {campaign.tag === "featured" && (
+          <span className="rounded border px-2 py-0.5 text-[10px] font-bold tracking-widest border-on-primary/30 text-on-primary">
+            FEATURED
+          </span>
+        )}
+      </div>
+
+      {/* Body */}
+      <h3 className="font-sora text-lg font-bold">{campaign.title}</h3>
+      <p className="text-sm leading-relaxed mt-2 line-clamp-2 opacity-80">
+        {campaign.description}
+      </p>
+
+      {/* Footer: budget + action icon */}
+      <div className="flex items-center justify-between mt-auto pt-4">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.05em] opacity-60">
+            BUDGET
+          </p>
+          <p className="font-sora text-lg font-bold">{campaign.budget}</p>
+        </div>
+        <div
+          className={`size-10 border flex items-center justify-center ${
+            isFeatured ? "border-on-primary/30" : "border-outline-variant"
+          }`}
+        >
+          {isFeatured ? (
+            <ArrowUpRight className="size-5" />
+          ) : (
+            <Plus className="size-5" />
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/components/explore/trending-campaigns.tsx
+++ b/apps/frontend/components/explore/trending-campaigns.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { trendingCampaigns } from "./explore-data";
+import { TrendingCampaignCard } from "./trending-campaign-card";
+
+export function TrendingCampaigns() {
+  return (
+    <section>
+      <div className="flex items-end justify-between mt-16 mb-6">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.05em] text-on-surface-variant">
+            GLOBAL OPPORTUNITIES
+          </p>
+          <h2 className="font-sora text-2xl font-bold text-on-surface">
+            Trending Campaigns
+          </h2>
+        </div>
+        <a
+          href="/marketplace"
+          className="text-sm font-semibold text-primary-container hover:underline"
+        >
+          View all campaigns →
+        </a>
+      </div>
+
+      <div className="flex gap-5 overflow-x-auto pb-4 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {trendingCampaigns.map((campaign) => (
+          <div key={campaign.id} className="snap-start shrink-0 w-[300px]">
+            <TrendingCampaignCard campaign={campaign} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/landing/Navbar.tsx
+++ b/apps/frontend/components/landing/Navbar.tsx
@@ -37,7 +37,7 @@ export function Navbar() {
           <a href="/marketplace" className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors">
             Marketplace
           </a>
-          <a href="#" className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors">
+          <a href="/explore" className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors">
             Explore
           </a>
           <a href="#" className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors">
@@ -69,7 +69,7 @@ export function Navbar() {
       {isMobileMenuOpen && (
         <div className="md:hidden bg-surface-container border-b border-outline-variant px-6 py-4 flex flex-col gap-4">
           <a href="/marketplace" className="text-[15px] text-on-surface py-2 font-medium">Marketplace</a>
-          <a href="#" className="text-[15px] text-on-surface-variant py-2">Explore</a>
+          <a href="/explore" className="text-[15px] text-on-surface-variant py-2">Explore</a>
           <a href="#" className="text-[15px] text-on-surface-variant py-2">Stats</a>
           <ConnectWalletButton />
         </div>


### PR DESCRIPTION
## Summary

Builds the public **Explore** page (`/explore`) — the discovery hub for trending campaigns, market insights, and top-rated creators — and wires it into the landing Navbar.

It uses the landing/public design-token system (no `--dash-*` tokens, no hardcoded hex values) and shares the `Navbar` and `Footer`.

## What's included

- **`app/explore/page.tsx`** — Server Component page composing the sections under the shared Navbar/Footer.
- **`components/explore/explore-data.ts`** — typed mock data (hashtags, trending campaigns, insight rows, payout trend, top creators).
- **`ExploreHero`** — bold italic `font-sora` headline + 5 hashtag pills.
- **`TrendingCampaigns`** (`"use client"`) — horizontally scrollable, snap-aligned campaign cards with a hidden scrollbar; "View all campaigns →" links to `/marketplace`.
- **`TrendingCampaignCard`** — `HOT` (red) / `FEATURED` (solid lime, inverted text) / plain variants, with `Plus` / `ArrowUpRight` action icons.
- **`MarketInsights`** — insight rows with lime delta values + payout-trend callout.
- **`TopCreators`** — 2×2 creator grid + disabled "Discover More Creators" button.
- **`CreatorAvatar`** — small leaf component that renders the avatar image and gracefully falls back to initials on a dark circle, so cards render cleanly even though the avatar images don't exist yet.
- **Navbar** — the "Explore" link (desktop + mobile) now points to `/explore`.

## Notes / deviations

- Structural rules followed: no `rounded` on outer containers, named exports for components, landing-page Tailwind utilities only.
- The spec said "Server Components except `TrendingCampaigns`". I added one tiny `"use client"` leaf (`CreatorAvatar`) purely to satisfy "render cleanly with missing avatar images" — pure SSR can't gracefully handle a broken `<img>`. `TopCreators` itself stays a Server Component. Happy to inline it if you'd prefer.

## Test plan

- [x] `npx tsc --noEmit` from `apps/frontend/` is clean.
- [x] `/explore` renders Hero, Trending Campaigns (HOT/FEATURED/plain), Market Insights, Top Creators.
- [x] Navbar "Explore" navigates to `/explore` (desktop + mobile); "View all campaigns →" → `/marketplace`.
- [x] Trending cards scroll horizontally with snap; bottom grid stacks on mobile.

> Note: the repo's lint currently crashes before running (`@eslint/eslintrc` "Converting circular structure to JSON" under ESLint 9) on `main`, independent of this change — so I verified types instead.

Closes #48
