### PR TITLE
Fix/dashboard role based redirect

### DIFF
--- a/apps/frontend/app/dashboard/error.tsx
+++ b/apps/frontend/app/dashboard/error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log dashboard error
+    console.error("Dashboard error caught:", error);
+  }, [error]);
+
+  return (
+    <div className="creator-dashboard-theme flex items-center justify-center min-h-[60vh] p-6 font-geist">
+      <div className="w-full max-w-md bg-[var(--dash-surface)] border border-[var(--dash-border)] rounded-xl p-8 text-center flex flex-col items-center shadow-lg">
+        {/* Icon */}
+        <div className="mb-6 p-4 rounded-full bg-[var(--dash-border)] border border-[var(--dash-border)]">
+          <AlertTriangle className="w-10 h-10 text-[var(--dash-accent)] animate-pulse" />
+        </div>
+
+        {/* Heading */}
+        <h2 className="font-sora font-bold text-2xl text-[var(--dash-heading)] tracking-tight mb-2">
+          Something went wrong
+        </h2>
+
+        {/* Description */}
+        <p className="text-[var(--dash-muted)] font-geist text-[15px] leading-relaxed mb-8 max-w-[340px]">
+          An unexpected error occurred. Please try again.
+        </p>
+
+        {/* Action Buttons */}
+        <div className="flex flex-col sm:flex-row gap-3 w-full justify-center">
+          <button
+            type="button"
+            onClick={() => reset()}
+            className="bg-[var(--dash-accent)] text-[var(--dash-on-accent)] font-geist font-semibold text-[15px] h-[44px] px-6 rounded-[4px] inline-flex items-center justify-center hover:opacity-90 transition-opacity cursor-pointer w-full sm:w-auto"
+          >
+            Try Again
+          </button>
+          <Link
+            href="/"
+            className="bg-transparent border border-[var(--dash-border)] text-[var(--dash-heading)] font-geist font-semibold text-[15px] h-[44px] px-6 rounded-[4px] inline-flex items-center justify-center hover:bg-white/5 transition-colors w-full sm:w-auto"
+          >
+            Go Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/dashboard/loading.tsx
+++ b/apps/frontend/app/dashboard/loading.tsx
@@ -1,0 +1,38 @@
+import { Loader2 } from "lucide-react";
+
+export default function DashboardLoading() {
+  return (
+    <div className="creator-dashboard-theme min-h-[70vh] p-6 font-geist flex flex-col gap-8">
+      {/* Header Skeleton */}
+      <div className="flex flex-col gap-3">
+        <div className="h-8 w-48 bg-[var(--dash-border)] rounded-md animate-pulse" />
+        <div className="h-4 w-72 bg-[var(--dash-border)] rounded-md animate-pulse" />
+      </div>
+
+      {/* Main Skeleton Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="bg-[var(--dash-surface)] border border-[var(--dash-border)] rounded-lg p-6 flex flex-col gap-4"
+          >
+            <div className="h-5 w-1/3 bg-[var(--dash-border)] rounded-md animate-pulse" />
+            <div className="h-8 w-2/3 bg-[var(--dash-border)] rounded-md animate-pulse" />
+            <div className="space-y-2 mt-2">
+              <div className="h-3.5 w-full bg-[var(--dash-border)] rounded-md animate-pulse" />
+              <div className="h-3.5 w-5/6 bg-[var(--dash-border)] rounded-md animate-pulse" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Centered Spinner */}
+      <div className="flex-1 flex flex-col items-center justify-center py-16">
+        <Loader2 className="w-10 h-10 animate-spin text-[var(--dash-accent)] mb-3" />
+        <span className="text-[var(--dash-muted)] font-geist font-medium text-[15px]">
+          Loading...
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -1,5 +1,22 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useRole } from "@/components/role/role-context";
 
 export default function DashboardPage() {
-  redirect("/dashboard/business");
+  const router = useRouter();
+  const { role } = useRole();
+
+  useEffect(() => {
+    if (role === "creator") {
+      router.replace("/dashboard/creator");
+    } else {
+      // Default to business dashboard; covers "business" and the null/unauthenticated case
+      router.replace("/dashboard/business");
+    }
+  }, [role, router]);
+
+  // Render nothing while the redirect is in flight
+  return null;
 }

--- a/apps/frontend/app/error.tsx
+++ b/apps/frontend/app/error.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { AlertCircle } from "lucide-react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to console
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center bg-background text-on-surface px-6 font-geist overflow-hidden">
+      {/* Decorative background glow */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[350px] h-[350px] bg-primary-container/10 rounded-full blur-[100px] pointer-events-none" />
+
+      <div className="relative z-10 text-center flex flex-col items-center max-w-lg w-full">
+        {/* Icon */}
+        <div className="mb-6 p-4 rounded-full bg-primary-container/10 border border-primary-container/20">
+          <AlertCircle className="w-12 h-12 text-primary-container animate-pulse" />
+        </div>
+
+        {/* Heading */}
+        <h1 className="font-sora font-extrabold text-3xl md:text-4xl tracking-tight mb-2">
+          Something went wrong
+        </h1>
+
+        {/* Description */}
+        <p className="text-on-surface-variant font-geist text-base md:text-lg mb-8 max-w-[420px]">
+          An unexpected error occurred. Please try again.
+        </p>
+
+        {/* Buttons */}
+        <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
+          <button
+            type="button"
+            onClick={() => reset()}
+            className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] inline-flex items-center justify-center hover:opacity-90 transition-opacity cursor-pointer w-full sm:w-auto"
+          >
+            Try Again
+          </button>
+          <Link
+            href="/"
+            className="bg-transparent border border-on-surface text-on-surface font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] inline-flex items-center justify-center hover:bg-on-surface/10 transition-colors w-full sm:w-auto"
+          >
+            Go Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Sora } from "next/font/google";
 import { WalletProvider } from "@/components/wallet/wallet-provider";
+import { RoleProvider } from "@/components/role/role-context";
 import { OnboardingModalProvider } from "@/components/onboarding/onboarding-modal-context";
 import { OnboardingWizardModal } from "@/components/onboarding/onboarding-wizard-modal";
 import "./globals.css";
@@ -41,10 +42,12 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} ${sora.variable} antialiased`}
       >
         <WalletProvider>
-          <OnboardingModalProvider>
-            {children}
-            <OnboardingWizardModal />
-          </OnboardingModalProvider>
+          <RoleProvider>
+            <OnboardingModalProvider>
+              {children}
+              <OnboardingWizardModal />
+            </OnboardingModalProvider>
+          </RoleProvider>
         </WalletProvider>
       </body>
     </html>

--- a/apps/frontend/app/marketplace/loading.tsx
+++ b/apps/frontend/app/marketplace/loading.tsx
@@ -1,0 +1,50 @@
+import { Loader2 } from "lucide-react";
+
+export default function MarketplaceLoading() {
+  return (
+    <div className="bg-background text-on-surface min-h-screen max-w-[1280px] mx-auto px-6 lg:px-10 pt-32 pb-20 font-geist flex flex-col gap-10">
+      {/* Hero Skeleton */}
+      <div className="flex flex-col gap-4 max-w-2xl">
+        <div className="h-4 w-32 bg-on-surface/10 rounded-md animate-pulse" />
+        <div className="h-12 w-3/4 bg-on-surface/10 rounded-md animate-pulse" />
+        <div className="h-6 w-full bg-on-surface/10 rounded-md animate-pulse" />
+      </div>
+
+      {/* Filter Bar Skeleton */}
+      <div className="h-14 w-full bg-on-surface/5 border border-on-surface/10 rounded-lg animate-pulse" />
+
+      {/* Grid of Card Skeletons */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div
+            key={i}
+            className="bg-on-surface/5 border border-on-surface/10 rounded-lg p-5 flex flex-col gap-4"
+          >
+            {/* Image Placeholder */}
+            <div className="w-full h-48 bg-on-surface/10 rounded-md animate-pulse" />
+            
+            {/* Content lines */}
+            <div className="h-4 w-1/4 bg-on-surface/10 rounded-md animate-pulse" />
+            <div className="h-6 w-3/4 bg-on-surface/10 rounded-md animate-pulse" />
+            
+            <div className="space-y-2 mt-2">
+              <div className="h-4 w-full bg-on-surface/10 rounded-md animate-pulse" />
+              <div className="h-4 w-5/6 bg-on-surface/10 rounded-md animate-pulse" />
+            </div>
+
+            {/* Footer action placeholder */}
+            <div className="h-10 w-full bg-on-surface/10 rounded-md animate-pulse mt-4" />
+          </div>
+        ))}
+      </div>
+
+      {/* Centered Loading Spinner */}
+      <div className="flex flex-col items-center justify-center py-12">
+        <Loader2 className="w-10 h-10 animate-spin text-primary-container mb-3" />
+        <span className="text-on-surface-variant font-medium text-[15px]">
+          Loading marketplace...
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/not-found.tsx
+++ b/apps/frontend/app/not-found.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "404 - Page Not Found | AdsBazaar",
+  description: "The page you're looking for doesn't exist or has been moved.",
+};
+
+export default function NotFound() {
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center bg-background text-on-surface px-6 font-geist overflow-hidden">
+      {/* Decorative background glow */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[350px] h-[350px] bg-primary-container/10 rounded-full blur-[100px] pointer-events-none" />
+
+      <div className="relative z-10 text-center flex flex-col items-center max-w-lg w-full">
+        {/* Large 404 Heading */}
+        <h1 className="font-sora font-extrabold text-[120px] md:text-[160px] leading-none tracking-tighter text-primary-container mb-4 selection:bg-on-primary selection:text-primary-container">
+          404
+        </h1>
+
+        {/* Subtitle */}
+        <h2 className="font-sora font-bold text-2xl md:text-3xl tracking-tight mb-2">
+          Page not found
+        </h2>
+
+        {/* Description */}
+        <p className="text-on-surface-variant font-geist text-base md:text-lg mb-8 max-w-[420px]">
+          The page you're looking for doesn't exist or has been moved.
+        </p>
+
+        {/* Buttons */}
+        <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
+          <Link
+            href="/"
+            className="bg-primary-container text-on-primary font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] inline-flex items-center justify-center hover:opacity-90 transition-opacity w-full sm:w-auto"
+          >
+            Go Home
+          </Link>
+          <Link
+            href="/marketplace"
+            className="bg-transparent border border-on-surface text-on-surface font-geist font-semibold text-[16px] h-[48px] px-8 rounded-[4px] inline-flex items-center justify-center hover:bg-on-surface/10 transition-colors w-full sm:w-auto"
+          >
+            Browse Marketplace
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/onboarding/onboarding-wizard-modal.tsx
+++ b/apps/frontend/components/onboarding/onboarding-wizard-modal.tsx
@@ -7,6 +7,7 @@ import { useOnboardingModal } from "./onboarding-modal-context";
 import { StepIndicator } from "./step-indicator";
 import { BusinessForm } from "./business-form";
 import { CreatorForm } from "./creator-form";
+import { useRole } from "@/components/role/role-context";
 
 type Role = "business" | "creator" | null;
 
@@ -34,6 +35,7 @@ const emptyCreatorForm = {
 
 export function OnboardingWizardModal() {
   const { isOpen, intent, closeOnboarding } = useOnboardingModal();
+  const { setRole: persistRole } = useRole();
   const router = useRouter();
   const mainRef = useRef<HTMLElement>(null);
 
@@ -84,6 +86,8 @@ export function OnboardingWizardModal() {
   }
 
   function handleFormSubmit() {
+    // Persist the chosen role to context + localStorage so /dashboard can redirect correctly
+    if (role) persistRole(role);
     setStep("complete");
     try {
       sessionStorage.removeItem(STORAGE_KEY);

--- a/apps/frontend/components/role/role-context.tsx
+++ b/apps/frontend/components/role/role-context.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+export type Role = "business" | "creator" | null;
+
+type RoleContextValue = {
+  role: Role;
+  setRole: (role: Role) => void;
+};
+
+const ROLE_STORAGE_KEY = "adsbazaar_role";
+
+const RoleContext = createContext<RoleContextValue | null>(null);
+
+export function RoleProvider({ children }: { children: React.ReactNode }) {
+  const [role, setRoleState] = useState<Role>(null);
+
+  // Hydrate from localStorage on mount (client-only)
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(ROLE_STORAGE_KEY);
+      if (stored === "business" || stored === "creator") {
+        setRoleState(stored);
+      }
+    } catch {
+      // localStorage may be unavailable in some environments
+    }
+  }, []);
+
+  const setRole = useCallback((newRole: Role) => {
+    setRoleState(newRole);
+    try {
+      if (newRole === null) {
+        localStorage.removeItem(ROLE_STORAGE_KEY);
+      } else {
+        localStorage.setItem(ROLE_STORAGE_KEY, newRole);
+      }
+    } catch {
+      // localStorage may be unavailable in some environments
+    }
+  }, []);
+
+  return (
+    <RoleContext.Provider value={{ role, setRole }}>
+      {children}
+    </RoleContext.Provider>
+  );
+}
+
+export function useRole(): RoleContextValue {
+  const ctx = useContext(RoleContext);
+  if (!ctx) {
+    throw new Error("useRole must be used within a RoleProvider");
+  }
+  return ctx;
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
-  - "apps/*"
-  - "packages/*"
+  - apps/*
+  - packages/*
+
+ignoredBuiltDependencies:
+  - sharp
+  - unrs-resolver

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,3 @@
 packages:
-  - apps/*
-  - packages/*
-
-ignoredBuiltDependencies:
-  - sharp
-  - unrs-resolver
+  - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
closed #56 
## fix(dashboard): role-based redirect and RoleContext persistence

### Summary

This PR fixes dashboard routing by making redirects role-aware and persisting the user's selected role across sessions.

Previously, `/dashboard` always redirected authenticated users to `/dashboard/business`, regardless of whether they selected **Creator** or **Business** during onboarding. The selected role was stored only in local component state and was lost once onboarding was completed.

### Changes

* Added a new `RoleContext` with localStorage persistence (`adsbazaar_role`)
* Wrapped the application with `RoleProvider` in `app/layout.tsx`
* Updated `/dashboard` to redirect users based on their persisted role
* Persisted the selected role when onboarding is completed
* Added a `useRole()` hook with provider validation to prevent misuse

### Result

* Creators are redirected to `/dashboard/creator`
* Business users are redirected to `/dashboard/business`
* Role selection survives page refreshes and browser restarts
* Existing fallback behavior remains unchanged for users without a role

### Testing

* Complete onboarding as a Creator → `/dashboard` redirects to `/dashboard/creator`
* Refresh and revisit `/dashboard` → still redirects correctly
* Repeat as a Business user → redirects to `/dashboard/business`
* Clear localStorage and visit `/dashboard` → falls back to `/dashboard/business`

### Notes

This is a client-side solution intended as a temporary persistence layer. When authentication is introduced, role data should be sourced from the user session/token and route-level guards can be added to prevent cross-role access.
