### PR TITLE
feat: build Settings page for creator and business dashboards #69

### DIFF
--- a/apps/frontend/app/dashboard/business/settings/page.tsx
+++ b/apps/frontend/app/dashboard/business/settings/page.tsx
@@ -1,17 +1,20 @@
 import { DashboardHeader } from "@/components/dashboard/business/dashboard-header";
+import { ProfileSection } from "@/components/dashboard/shared/profile-section";
+import { WalletSettingsSection } from "@/components/dashboard/shared/wallet-settings-section";
+import { NotificationPreferences } from "@/components/dashboard/shared/notification-preferences";
+import { DangerZoneSection } from "@/components/dashboard/shared/danger-zone-section";
+import { businessProfile } from "@/components/dashboard/shared/settings-data";
 
 export default function BusinessSettingsPage() {
   return (
     <>
       <DashboardHeader eyebrow="Account preferences" title="Settings" />
 
-      <div className="flex flex-col items-center justify-center gap-2 border border-[var(--dash-border)] bg-[var(--dash-surface)] px-6 py-20 text-center">
-        <p className="text-sm font-medium text-[var(--dash-heading)]">
-          This page is under construction.
-        </p>
-        <p className="max-w-md text-sm text-[var(--dash-muted)]">
-          Business profile, billing, and notification settings coming soon.
-        </p>
+      <div className="flex flex-col gap-8">
+        <ProfileSection profile={businessProfile} />
+        <WalletSettingsSection />
+        <NotificationPreferences role="business" />
+        <DangerZoneSection />
       </div>
     </>
   );

--- a/apps/frontend/app/dashboard/creator/settings/page.tsx
+++ b/apps/frontend/app/dashboard/creator/settings/page.tsx
@@ -1,17 +1,20 @@
 import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
+import { ProfileSection } from "@/components/dashboard/shared/profile-section";
+import { WalletSettingsSection } from "@/components/dashboard/shared/wallet-settings-section";
+import { NotificationPreferences } from "@/components/dashboard/shared/notification-preferences";
+import { DangerZoneSection } from "@/components/dashboard/shared/danger-zone-section";
+import { creatorProfile } from "@/components/dashboard/shared/settings-data";
 
 export default function CreatorSettingsPage() {
   return (
     <>
       <DashboardHeader eyebrow="Account preferences" title="Settings" />
 
-      <div className="flex flex-col items-center justify-center gap-2 border border-[var(--dash-border)] bg-[var(--dash-surface)] px-6 py-20 text-center">
-        <p className="text-sm font-medium text-[var(--dash-heading)]">
-          This page is under construction.
-        </p>
-        <p className="max-w-md text-sm text-[var(--dash-muted)]">
-          Profile settings and notification preferences coming soon.
-        </p>
+      <div className="flex flex-col gap-8">
+        <ProfileSection profile={creatorProfile} />
+        <WalletSettingsSection />
+        <NotificationPreferences role="creator" />
+        <DangerZoneSection />
       </div>
     </>
   );

--- a/apps/frontend/components/dashboard/shared/danger-zone-section.tsx
+++ b/apps/frontend/components/dashboard/shared/danger-zone-section.tsx
@@ -1,0 +1,33 @@
+export function DangerZoneSection() {
+  return (
+    <section className="border border-red-400/30 bg-[var(--dash-surface)] p-6">
+      <h2 className="mb-4 text-sm font-semibold text-[var(--dash-heading)]">
+        Danger zone
+      </h2>
+
+      <p className="mb-6 max-w-2xl text-sm text-[var(--dash-muted)]">
+        This action is irreversible. All campaign data and wallet associations
+        will be permanently removed.
+      </p>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <button
+          type="button"
+          disabled
+          title="Coming soon"
+          className="border border-red-400 px-4 py-2 text-sm font-semibold text-red-400 transition-colors hover:bg-red-400/10 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent"
+        >
+          Deactivate Account
+        </button>
+        <button
+          type="button"
+          disabled
+          title="Coming soon"
+          className="bg-red-400 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-red-400"
+        >
+          Delete Account
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/dashboard/shared/notification-preferences.tsx
+++ b/apps/frontend/components/dashboard/shared/notification-preferences.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import type { UserProfile } from "./settings-data";
+
+type ToggleItem = {
+  id: string;
+  label: string;
+  description: string;
+  defaultOn: boolean;
+};
+
+function buildToggles(role: UserProfile["role"]): ToggleItem[] {
+  return [
+    {
+      id: "campaign-updates",
+      label: "Campaign updates",
+      description: "Status changes on campaigns you're part of.",
+      defaultOn: true,
+    },
+    {
+      id: "payout-notifications",
+      label: "Payout notifications",
+      description: "Alerts when funds settle or become claimable.",
+      defaultOn: true,
+    },
+    role === "business"
+      ? {
+          id: "new-applicants",
+          label: "New applicants",
+          description: "When a creator applies to one of your campaigns.",
+          defaultOn: true,
+        }
+      : {
+          id: "campaign-match-alerts",
+          label: "Campaign match alerts",
+          description: "When a new campaign matches your audience.",
+          defaultOn: true,
+        },
+    {
+      id: "marketing-emails",
+      label: "Marketing emails",
+      description: "Product news and occasional promotions.",
+      defaultOn: false,
+    },
+  ];
+}
+
+export function NotificationPreferences({
+  role,
+}: {
+  role: UserProfile["role"];
+}) {
+  const toggles = buildToggles(role);
+  const [state, setState] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(toggles.map((t) => [t.id, t.defaultOn])),
+  );
+
+  return (
+    <section className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-6">
+      <h2 className="mb-4 text-sm font-semibold text-[var(--dash-heading)]">
+        Notification preferences
+      </h2>
+
+      <div className="flex flex-col divide-y divide-[var(--dash-border)]">
+        {toggles.map((toggle) => {
+          const isOn = state[toggle.id];
+          return (
+            <div
+              key={toggle.id}
+              className="flex items-center justify-between gap-4 py-4 first:pt-0 last:pb-0"
+            >
+              <div>
+                <p className="text-sm text-[var(--dash-body)]">
+                  {toggle.label}
+                </p>
+                <p className="text-xs text-[var(--dash-muted)]">
+                  {toggle.description}
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={isOn}
+                aria-label={toggle.label}
+                onClick={() =>
+                  setState((prev) => ({ ...prev, [toggle.id]: !prev[toggle.id] }))
+                }
+                className={`flex size-10 shrink-0 items-center rounded-full px-1 transition-colors ${
+                  isOn ? "bg-[var(--dash-accent)]" : "bg-[var(--dash-border)]"
+                }`}
+              >
+                <span
+                  className={`size-5 rounded-full bg-[var(--dash-surface)] transition-transform ${
+                    isOn ? "translate-x-3" : "translate-x-0"
+                  }`}
+                />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/dashboard/shared/profile-section.tsx
+++ b/apps/frontend/components/dashboard/shared/profile-section.tsx
@@ -1,0 +1,54 @@
+import { User } from "lucide-react";
+import type { UserProfile } from "./settings-data";
+
+export function ProfileSection({ profile }: { profile: UserProfile }) {
+  return (
+    <section className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-6">
+      <h2 className="mb-4 text-sm font-semibold text-[var(--dash-heading)]">
+        Profile
+      </h2>
+
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-start">
+        <div className="flex size-16 shrink-0 items-center justify-center rounded-full bg-[var(--dash-border)]">
+          <User className="size-7 text-[var(--dash-muted)]" aria-hidden="true" />
+        </div>
+
+        <div className="flex-1">
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+            <div>
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+                Display name
+              </p>
+              <p className="text-sm text-[var(--dash-body)]">
+                {profile.displayName}
+              </p>
+            </div>
+
+            <div>
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+                Email
+              </p>
+              <p className="text-sm text-[var(--dash-body)]">{profile.email}</p>
+            </div>
+
+            <div className="sm:col-span-2">
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+                Bio
+              </p>
+              <p className="text-sm text-[var(--dash-body)]">{profile.bio}</p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            disabled
+            title="Coming soon"
+            className="mt-6 border border-[var(--dash-border)] px-4 py-2 text-sm font-semibold text-[var(--dash-body)] transition-colors hover:border-[var(--dash-accent)] hover:text-[var(--dash-accent)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-[var(--dash-border)] disabled:hover:text-[var(--dash-body)]"
+          >
+            Edit Profile
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/dashboard/shared/settings-data.ts
+++ b/apps/frontend/components/dashboard/shared/settings-data.ts
@@ -1,0 +1,20 @@
+export type UserProfile = {
+  displayName: string;
+  email: string;
+  bio: string;
+  role: "business" | "creator";
+};
+
+export const businessProfile: UserProfile = {
+  displayName: "Stellar Labs Inc.",
+  email: "admin@stellarlabs.io",
+  bio: "Building the future of decentralized advertising on Stellar.",
+  role: "business",
+};
+
+export const creatorProfile: UserProfile = {
+  displayName: "Alexa Vibe",
+  email: "alexa@vibestudio.co",
+  bio: "Lifestyle & tech content creator. 1.7M+ reach across platforms.",
+  role: "creator",
+};

--- a/apps/frontend/components/dashboard/shared/wallet-settings-section.tsx
+++ b/apps/frontend/components/dashboard/shared/wallet-settings-section.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Wallet } from "lucide-react";
+import { useWallet } from "@/components/wallet/wallet-context";
+
+const shortenAddress = (address: string) =>
+  `${address.slice(0, 4)}...${address.slice(-4)}`;
+
+export function WalletSettingsSection() {
+  const { wallet, isConnecting, connect } = useWallet();
+
+  return (
+    <section className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-6">
+      <h2 className="mb-4 text-sm font-semibold text-[var(--dash-heading)]">
+        Wallet settings
+      </h2>
+
+      <div className="flex flex-col gap-6">
+        <div>
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+            Connected wallet
+          </p>
+          {wallet ? (
+            <div className="flex items-center gap-2">
+              <Wallet
+                className="size-[18px] text-[var(--dash-accent)]"
+                aria-hidden="true"
+              />
+              <span className="font-mono text-sm text-[var(--dash-body)]">
+                {shortenAddress(wallet.address)}
+              </span>
+              <span className="text-xs text-[var(--dash-muted)]">
+                ({wallet.network})
+              </span>
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-sm text-[var(--dash-body)]">
+                No wallet connected
+              </span>
+              <button
+                type="button"
+                onClick={connect}
+                disabled={isConnecting}
+                className="flex items-center gap-2 border border-[var(--dash-border)] px-4 py-2 text-sm font-semibold text-[var(--dash-body)] transition-colors hover:border-[var(--dash-accent)] hover:text-[var(--dash-accent)] disabled:cursor-wait disabled:opacity-60"
+              >
+                <Wallet className="size-4" aria-hidden="true" />
+                {isConnecting ? "Connecting..." : "Connect"}
+              </button>
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="settlement-asset"
+            className="mb-1 block text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]"
+          >
+            Default settlement asset
+          </label>
+          <select
+            id="settlement-asset"
+            disabled
+            title="Coming soon"
+            defaultValue="USDC"
+            className="w-full max-w-xs border border-[var(--dash-border)] bg-[var(--dash-surface)] px-3 py-2 text-sm text-[var(--dash-body)] disabled:cursor-not-allowed disabled:opacity-60 sm:max-w-[220px]"
+          >
+            <option value="USDC">USDC</option>
+            <option value="XLM">XLM</option>
+            <option value="EURC">EURC</option>
+          </select>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm text-[var(--dash-body)]">Auto-claim payouts</p>
+            <p className="text-xs text-[var(--dash-muted)]">
+              Automatically claim payouts as soon as they settle.
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled
+            title="Coming soon"
+            aria-label="Toggle auto-claim payouts"
+            className="flex size-10 shrink-0 items-center rounded-full bg-[var(--dash-border)] px-1 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <span className="size-5 rounded-full bg-[var(--dash-surface)]" />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## feat: Build Settings page for both creator and business dashboards

Closes #69

### Problem
Both `/dashboard/creator/settings` and `/dashboard/business/settings` were stubs showing "This page is under construction" — the last remaining placeholder pages in the dashboards. Settings is a core feature: without it there's no way to view profile information, manage wallet preferences, or configure notifications.

### What changed
Replaced both stubs with full settings pages built from **shared, role-aware components**. Since both dashboards use the same `--dash-*` token system and identical layouts, the sections are shared and parameterized by role.

### New shared components — `components/dashboard/shared/`
| File | Purpose |
|------|---------|
| `settings-data.ts` | `UserProfile` type + `businessProfile` / `creatorProfile` mock data |
| `profile-section.tsx` | `size-16` avatar placeholder (`User` icon), display-only name / email / bio, disabled **Edit Profile** |
| `wallet-settings-section.tsx` *(client)* | Reads `useWallet()` — shows shortened address + network, or "No wallet connected" with a **Connect** button; disabled settlement-asset dropdown (USDC/XLM/EURC) + auto-claim toggle |
| `notification-preferences.tsx` *(client)* | `size-10` / `size-5` lime toggles with local state. Business shows **New applicants**; creator shows **Campaign match alerts** |
| `danger-zone-section.tsx` | `border-red-400/30` container, disabled **Deactivate** / **Delete** buttons, irreversibility warning |

### Pages
- `app/dashboard/creator/settings/page.tsx` — composes the four sections (role `"creator"`)
- `app/dashboard/business/settings/page.tsx` — composes the four sections (role `"business"`)

Both render under their existing `DashboardHeader` (mobile hamburger preserved).
