### PR TITLE
feat: build business campaigns list page — cards, filters & stats (#49)

### DIFF
--- a/apps/frontend/app/dashboard/business/campaigns/page.tsx
+++ b/apps/frontend/app/dashboard/business/campaigns/page.tsx
@@ -1,32 +1,25 @@
-import { DashboardHeader } from "@/components/dashboard/business/dashboard-header";
+import { CampaignsPageHeader } from "@/components/dashboard/business/campaigns-page-header";
+import { CampaignsStatCards } from "@/components/dashboard/business/campaigns-stat-cards";
+import { CampaignsFilterBar } from "@/components/dashboard/business/campaigns-filter-bar";
+import { CampaignListCard } from "@/components/dashboard/business/campaign-list-card";
+import { CampaignsLoadMore } from "@/components/dashboard/business/campaigns-load-more";
+import { campaignsList } from "@/components/dashboard/business/campaigns-list-data";
 
-/**
- * Placeholder route. Full implementation tracked in
- * https://github.com/Ads-Bazaar/ads-bazaar/issues/49 — see that issue for the
- * file structure, components, design tokens, and acceptance criteria before
- * building this page out.
- */
 export default function BusinessCampaignsPage() {
   return (
     <>
-      <DashboardHeader eyebrow="Manage your briefs" title="Campaigns" />
+      <CampaignsPageHeader />
+      <CampaignsStatCards />
+      <CampaignsFilterBar />
 
-      <div className="flex flex-col items-center justify-center gap-2 border border-[var(--dash-border)] bg-[var(--dash-surface)] px-6 py-20 text-center">
-        <p className="text-sm font-medium text-[var(--dash-heading)]">
-          This page is under construction.
-        </p>
-        <p className="max-w-md text-sm text-[var(--dash-muted)]">
-          Full implementation is tracked in{" "}
-          <a
-            href="https://github.com/Ads-Bazaar/ads-bazaar/issues/49"
-            className="text-[var(--dash-accent)] hover:underline"
-          >
-            Issue #49
-          </a>
-          . Replace this file according to that spec — do not add a sidebar or
-          layout wrapper, the business dashboard shell already provides it.
-        </p>
+      {/* Campaign cards grid */}
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {campaignsList.map((campaign) => (
+          <CampaignListCard key={campaign.id} campaign={campaign} />
+        ))}
       </div>
+
+      <CampaignsLoadMore />
     </>
   );
 }

--- a/apps/frontend/components/dashboard/business/campaign-list-card.tsx
+++ b/apps/frontend/components/dashboard/business/campaign-list-card.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import Link from "next/link";
+import type { CampaignListItem } from "./campaigns-list-data";
+
+const statusBadgeStyles: Record<CampaignListItem["status"], string> = {
+  active: "border-[var(--dash-accent)] text-[var(--dash-accent)]",
+  "under-review": "border-amber-400 text-amber-400",
+  draft: "border-[var(--dash-border)] text-[var(--dash-muted)]",
+  completed: "border-blue-400 text-blue-400",
+};
+
+const statusLabels: Record<CampaignListItem["status"], string> = {
+  active: "ACTIVE",
+  "under-review": "UNDER REVIEW",
+  draft: "DRAFT",
+  completed: "COMPLETED",
+};
+
+function MetricCell({
+  label,
+  value,
+  accent = false,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <div>
+      <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+        {label}
+      </p>
+      <p
+        className={`text-sm font-bold ${
+          accent ? "text-[var(--dash-accent)]" : "text-[var(--dash-heading)]"
+        }`}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function CampaignListCard({ campaign }: { campaign: CampaignListItem }) {
+  return (
+    <article className="border border-[var(--dash-border)] bg-[var(--dash-surface)] overflow-hidden">
+      {/* Hero image — dark bg is the fallback since images won't exist locally */}
+      <div
+        className="relative h-40 overflow-hidden bg-[var(--dash-bg)]"
+        style={{
+          backgroundImage: `url(${campaign.heroImagePath})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+        role="img"
+        aria-label={campaign.title}
+      >
+        {/* Status badge */}
+        <span
+          className={`absolute top-3 right-3 rounded border px-2 py-0.5 text-[10px] font-bold tracking-widest ${
+            statusBadgeStyles[campaign.status]
+          }`}
+        >
+          {statusLabels[campaign.status]}
+        </span>
+      </div>
+
+      {/* Content */}
+      <div className="p-5">
+        <h3 className="font-[family-name:var(--font-sora)] text-lg font-bold leading-tight text-[var(--dash-heading)]">
+          {campaign.title}
+        </h3>
+        <p className="mt-1 text-xs text-[var(--dash-body)]">{campaign.dateRange}</p>
+
+        {/* Status-specific metrics */}
+        {campaign.status === "active" && (
+          <div className="mt-4 border-t border-[var(--dash-border)] pt-4">
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCell label="Budget" value={campaign.budget} />
+              <MetricCell label="Applicants" value={campaign.applicants} />
+            </div>
+            <div className="my-3 border-t border-[var(--dash-border)]" />
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCell
+                label="Impressions"
+                value={campaign.impressions ?? "—"}
+                accent
+              />
+              <MetricCell label="Avg. Reach" value={campaign.avgReach ?? "—"} />
+            </div>
+            <Link
+              href={`/dashboard/business/campaigns/${campaign.id}`}
+              className="mt-4 block w-full bg-[var(--dash-accent-strong)] py-3 text-center font-bold text-[var(--dash-on-accent-strong)] transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+            >
+              View Details
+            </Link>
+          </div>
+        )}
+
+        {campaign.status === "under-review" && (
+          <div className="mt-4 border-t border-[var(--dash-border)] pt-4">
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCell label="Budget" value={campaign.budget} />
+              <MetricCell label="Applicants" value={campaign.applicants} />
+            </div>
+            <div className="my-3 border-t border-[var(--dash-border)]" />
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCell
+                label="Est. Impressions"
+                value={campaign.estImpressions ?? "—"}
+              />
+              <MetricCell label="Est. Reach" value={campaign.estReach ?? "—"} />
+            </div>
+            <button
+              type="button"
+              disabled
+              title="Coming soon"
+              className="mt-4 w-full border border-[var(--dash-border)] py-3 text-center font-bold text-[var(--dash-heading)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              View Submission
+            </button>
+          </div>
+        )}
+
+        {campaign.status === "draft" && (
+          <div className="mt-4 border-t border-[var(--dash-border)] pt-4">
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCell label="Budget" value={campaign.budget} />
+              <MetricCell label="Applicants" value={campaign.applicants} />
+            </div>
+            {campaign.draftNote && (
+              <p className="mt-3 text-sm italic text-[var(--dash-muted)]">
+                {campaign.draftNote}
+              </p>
+            )}
+            <button
+              type="button"
+              disabled
+              title="Coming soon"
+              className="mt-4 w-full border border-[var(--dash-border)] py-3 text-center font-bold text-[var(--dash-muted)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Continue Draft
+            </button>
+          </div>
+        )}
+
+        {campaign.status === "completed" && (
+          <div className="mt-4 border-t border-[var(--dash-border)] pt-4">
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCell label="Total Spent" value={campaign.totalSpent ?? "—"} />
+              <MetricCell label="Final Reach" value={campaign.finalReach ?? "—"} />
+            </div>
+            <div className="my-3 border-t border-[var(--dash-border)]" />
+            <div className="grid grid-cols-2 gap-4">
+              <MetricCell
+                label="ROI Score"
+                value={campaign.roiScore ?? "—"}
+                accent
+              />
+              <MetricCell
+                label="Creators Paid"
+                value={campaign.creatorsPaid ?? "—"}
+              />
+            </div>
+            <button
+              type="button"
+              disabled
+              title="Coming soon"
+              className="mt-4 w-full border border-[var(--dash-border)] py-3 text-center font-bold text-[var(--dash-heading)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              View Report
+            </button>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/components/dashboard/business/campaigns-filter-bar.tsx
+++ b/apps/frontend/components/dashboard/business/campaigns-filter-bar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { Search } from "lucide-react";
+import { filterTabs } from "./campaigns-list-data";
+
+export function CampaignsFilterBar() {
+  const [activeTab, setActiveTab] = useState("All");
+
+  return (
+    <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+      {/* Tab filters */}
+      <div className="flex flex-wrap gap-2" role="tablist" aria-label="Campaign status filters">
+        {filterTabs.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-2 text-sm font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] ${
+              activeTab === tab
+                ? "rounded bg-[var(--dash-accent)] text-[var(--dash-on-accent)]"
+                : "text-[var(--dash-muted)] hover:text-[var(--dash-heading)]"
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {/* Search + Sort */}
+      <div className="flex items-center gap-3">
+        <div className="relative">
+          <Search
+            className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-[var(--dash-muted)]"
+            aria-hidden="true"
+          />
+          <input
+            type="text"
+            placeholder="Filter by name..."
+            disabled
+            title="Coming soon"
+            className="w-48 border border-[var(--dash-border)] bg-[var(--dash-surface)] py-2 pr-4 pl-9 text-sm text-[var(--dash-body)] placeholder:text-[var(--dash-muted)]/50 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+          />
+        </div>
+        <select
+          disabled
+          title="Coming soon"
+          className="border border-[var(--dash-border)] bg-[var(--dash-surface)] px-4 py-2 text-sm text-[var(--dash-muted)] disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+          aria-label="Sort campaigns"
+        >
+          <option>Sort By: Newest</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/business/campaigns-list-data.ts
+++ b/apps/frontend/components/dashboard/business/campaigns-list-data.ts
@@ -1,0 +1,85 @@
+export type CampaignListStatus =
+  | "active"
+  | "under-review"
+  | "draft"
+  | "completed";
+
+export type CampaignListItem = {
+  id: string;
+  title: string;
+  dateRange: string;
+  status: CampaignListStatus;
+  heroImagePath: string;
+  budget: string;
+  applicants: string;
+  // Active campaigns
+  impressions?: string;
+  avgReach?: string;
+  // Under review campaigns
+  estImpressions?: string;
+  estReach?: string;
+  // Completed campaigns
+  totalSpent?: string;
+  finalReach?: string;
+  roiScore?: string;
+  creatorsPaid?: string;
+  // Draft campaigns
+  draftNote?: string;
+};
+
+export const campaignsPageStats = {
+  totalCampaigns: { value: "124", delta: "+12%" },
+  activeNow: { value: "18", indicator: true },
+  pendingReview: { value: "06", sub: "In queue" },
+  totalBudgetLocked: { value: "142.5k", unit: "XLM" },
+};
+
+export const campaignsList: CampaignListItem[] = [
+  {
+    id: "cyberpunk-rebrand",
+    title: "Cyberpunk Rebrand – Q4 Launch",
+    dateRange: "Oct 12 – Dec 15, 2024",
+    status: "active",
+    heroImagePath: "/images/campaign-cyberpunk.jpg",
+    budget: "45,000 XLM",
+    applicants: "12 Creators",
+    impressions: "1.2M",
+    avgReach: "340k",
+  },
+  {
+    id: "stellar-fitness",
+    title: "Stellar Fitness App Promo",
+    dateRange: "Jan 05 – Feb 28, 2025",
+    status: "under-review",
+    heroImagePath: "/images/campaign-fitness.jpg",
+    budget: "12,500 XLM",
+    applicants: "42 Creators",
+    estImpressions: "—",
+    estReach: "—",
+  },
+  {
+    id: "nft-gallery",
+    title: "NFT Gallery Summer Tour",
+    dateRange: "Pending Dates",
+    status: "draft",
+    heroImagePath: "/images/campaign-nft.jpg",
+    budget: "8,000 XLM",
+    applicants: "0",
+    draftNote: "Complete campaign setup to launch",
+  },
+  {
+    id: "defi-education",
+    title: "DeFi Protocol Education",
+    dateRange: "Aug 01 – Sep 15, 2024",
+    status: "completed",
+    heroImagePath: "/images/campaign-defi.jpg",
+    budget: "",
+    applicants: "",
+    totalSpent: "22,400 XLM",
+    finalReach: "890k",
+    roiScore: "4.8/5",
+    creatorsPaid: "15",
+  },
+];
+
+export const filterTabs = ["All", "Active", "Scheduled", "Drafts", "Completed"];

--- a/apps/frontend/components/dashboard/business/campaigns-load-more.tsx
+++ b/apps/frontend/components/dashboard/business/campaigns-load-more.tsx
@@ -1,0 +1,14 @@
+export function CampaignsLoadMore() {
+  return (
+    <div className="mt-8 flex justify-center">
+      <button
+        type="button"
+        disabled
+        title="Coming soon"
+        className="border border-[var(--dash-border)] px-8 py-3 text-sm font-bold tracking-widest text-[var(--dash-muted)] transition-colors hover:border-[var(--dash-accent)] hover:text-[var(--dash-accent)] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        LOAD MORE CAMPAIGNS ∨
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/business/campaigns-page-header.tsx
+++ b/apps/frontend/components/dashboard/business/campaigns-page-header.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Wand2 } from "lucide-react";
+import { useWizardModal } from "./wizard-modal-context";
+
+export function CampaignsPageHeader() {
+  const { openWizard } = useWizardModal();
+
+  return (
+    <div className="mb-8 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h1 className="font-[family-name:var(--font-sora)] text-[28px] font-semibold text-[var(--dash-heading)]">
+          Campaigns
+        </h1>
+        <p className="mt-1 text-sm text-[var(--dash-muted)]">
+          Manage and monitor your decentralized advertising ventures.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={openWizard}
+        className="flex items-center gap-2 bg-[var(--dash-accent-strong)] px-5 py-3 font-bold text-[var(--dash-on-accent-strong)] transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+      >
+        <Wand2 className="size-4" aria-hidden="true" />
+        Create New Campaign
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/components/dashboard/business/campaigns-stat-cards.tsx
+++ b/apps/frontend/components/dashboard/business/campaigns-stat-cards.tsx
@@ -1,0 +1,65 @@
+import { campaignsPageStats } from "./campaigns-list-data";
+
+export function CampaignsStatCards() {
+  const { totalCampaigns, activeNow, pendingReview, totalBudgetLocked } =
+    campaignsPageStats;
+
+  return (
+    <div className="mb-8 grid grid-cols-2 gap-4 lg:grid-cols-4">
+      {/* Total Campaigns */}
+      <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-5">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+          Total Campaigns
+        </p>
+        <p className="font-[family-name:var(--font-sora)] text-[28px] font-semibold text-[var(--dash-heading)]">
+          {totalCampaigns.value}
+        </p>
+        <span className="text-xs font-bold text-[var(--dash-accent)]">
+          {totalCampaigns.delta}
+        </span>
+      </div>
+
+      {/* Active Now */}
+      <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-5">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+          Active Now
+        </p>
+        <p className="flex items-center font-[family-name:var(--font-sora)] text-[28px] font-semibold text-[var(--dash-heading)]">
+          {activeNow.value}
+          {activeNow.indicator && (
+            <span
+              className="ml-2 inline-block size-2 rounded-full bg-[var(--dash-accent)]"
+              aria-label="Active indicator"
+            />
+          )}
+        </p>
+      </div>
+
+      {/* Pending Review */}
+      <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-5">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+          Pending Review
+        </p>
+        <p className="font-[family-name:var(--font-sora)] text-[28px] font-semibold text-[var(--dash-heading)]">
+          {pendingReview.value}
+        </p>
+        <span className="text-xs text-[var(--dash-muted)]">
+          {pendingReview.sub}
+        </span>
+      </div>
+
+      {/* Total Budget Locked */}
+      <div className="border border-[var(--dash-border)] bg-[var(--dash-surface)] p-5">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.05em] text-[var(--dash-muted)]">
+          Total Budget Locked
+        </p>
+        <p className="font-[family-name:var(--font-sora)] text-[28px] font-semibold text-[var(--dash-heading)]">
+          {totalBudgetLocked.value}
+          <span className="ml-1 text-sm font-bold text-[var(--dash-muted)]">
+            {totalBudgetLocked.unit}
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Replace stub at app/dashboard/business/campaigns/page.tsx
- Add campaigns-list-data.ts with typed mock data and page stats
- Add CampaignsPageHeader with Create New Campaign button (openWizard)
- Add CampaignsStatCards: 4 stat cards with delta, indicator, sub labels
- Add CampaignsFilterBar: tab filters (client), search + sort (disabled)
- Add CampaignListCard: status-specific layouts for active/under-review/draft/completed
- Add CampaignsLoadMore: disabled button with coming-soon title
- 3-col grid (responsive: 1-col mobile, 2-col sm, 3-col lg)
- All styling via --dash-* CSS tokens, no hardcoded hex values
- TypeScript compiles clean, no outer rounded on card containers   closes #49 