### PR TITLE
feat: implement unique browser tab titles for dashboard layouts and marketplace pages

### DIFF
--- a/apps/frontend/app/dashboard/business/analytics/page.tsx
+++ b/apps/frontend/app/dashboard/business/analytics/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import {
   analyticsStats,
   spendEngagementSeries,
@@ -5,6 +6,10 @@ import {
   topCampaigns,
   regionRows,
 } from "@/components/dashboard/business/analytics-data";
+
+export const metadata: Metadata = {
+  title: "Analytics",
+};
 import { AnalyticsHeader } from "@/components/dashboard/business/analytics-header";
 import { DashboardHeader } from "@/components/dashboard/business/dashboard-header";
 import { AnalyticsStatCard } from "@/components/dashboard/business/analytics-stat-card";

--- a/apps/frontend/app/dashboard/business/layout.tsx
+++ b/apps/frontend/app/dashboard/business/layout.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import { Sora } from "next/font/google";
 import { DashboardChrome } from "@/components/dashboard/business/dashboard-chrome";
+
+export const metadata: Metadata = {
+  title: {
+    template: "%s — AdsBazaar Business",
+    default: "Dashboard — AdsBazaar Business",
+  },
+};
 
 const sora = Sora({
   subsets: ["latin"],

--- a/apps/frontend/app/dashboard/business/payouts/page.tsx
+++ b/apps/frontend/app/dashboard/business/payouts/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { DashboardHeader } from '@/components/dashboard/business/dashboard-header';
 import { PayoutsHeader } from '@/components/dashboard/business/payouts-header';
+
+export const metadata: Metadata = {
+  title: "Payouts",
+};
 import { EscrowStatCard } from '@/components/dashboard/business/escrow-stat-card';
 import { WalletAssetsPanel } from '@/components/dashboard/business/wallet-assets-panel';
 import { SorobanContractsSection } from '@/components/dashboard/business/soroban-contracts-section';

--- a/apps/frontend/app/dashboard/business/settings/page.tsx
+++ b/apps/frontend/app/dashboard/business/settings/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { DashboardHeader } from "@/components/dashboard/business/dashboard-header";
 import { ProfileSection } from "@/components/dashboard/shared/profile-section";
+
+export const metadata: Metadata = {
+  title: "Settings",
+};
 import { WalletSettingsSection } from "@/components/dashboard/shared/wallet-settings-section";
 import { NotificationPreferences } from "@/components/dashboard/shared/notification-preferences";
 import { DangerZoneSection } from "@/components/dashboard/shared/danger-zone-section";

--- a/apps/frontend/app/dashboard/creator/analytics/page.tsx
+++ b/apps/frontend/app/dashboard/creator/analytics/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
 import { analyticStats, growthSeries, ageGroups, topLocations, channels, topCampaigns } from "@/components/dashboard/creator/creator-analytics-data";
+
+export const metadata: Metadata = {
+  title: "Analytics",
+};
 import { AnalyticsPageHeader } from "@/components/dashboard/creator/analytics-page-header";
 import { AnalyticsStatCards } from "@/components/dashboard/creator/analytics-stat-cards";
 import { FollowerGrowthChart } from "@/components/dashboard/creator/follower-growth-chart";

--- a/apps/frontend/app/dashboard/creator/inventory/page.tsx
+++ b/apps/frontend/app/dashboard/creator/inventory/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
 import { ConnectedChannels } from "@/components/dashboard/creator/connected-channels";
+
+export const metadata: Metadata = {
+  title: "Inventory",
+};
 import { DigitalMediaKit } from "@/components/dashboard/creator/digital-media-kit";
 import { AudienceInsights } from "@/components/dashboard/creator/audience-insights";
 import { SyncSchedule } from "@/components/dashboard/creator/sync-schedule";

--- a/apps/frontend/app/dashboard/creator/layout.tsx
+++ b/apps/frontend/app/dashboard/creator/layout.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import { Sora } from "next/font/google";
 import { DashboardChrome } from "@/components/dashboard/creator/dashboard-chrome";
+
+export const metadata: Metadata = {
+  title: {
+    template: "%s — AdsBazaar Creator",
+    default: "Dashboard — AdsBazaar Creator",
+  },
+};
 
 const sora = Sora({
   subsets: ["latin"],

--- a/apps/frontend/app/dashboard/creator/payouts/page.tsx
+++ b/apps/frontend/app/dashboard/creator/payouts/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { Timer, TrendingUp } from "lucide-react";
 import { ClaimableCard } from "@/components/dashboard/creator/claimable-card";
+
+export const metadata: Metadata = {
+  title: "Payouts",
+};
 import {
   connectedWallet,
   currentCycle,

--- a/apps/frontend/app/dashboard/creator/settings/page.tsx
+++ b/apps/frontend/app/dashboard/creator/settings/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { DashboardHeader } from "@/components/dashboard/creator/dashboard-header";
 import { ProfileSection } from "@/components/dashboard/shared/profile-section";
+
+export const metadata: Metadata = {
+  title: "Settings",
+};
 import { WalletSettingsSection } from "@/components/dashboard/shared/wallet-settings-section";
 import { NotificationPreferences } from "@/components/dashboard/shared/notification-preferences";
 import { DangerZoneSection } from "@/components/dashboard/shared/danger-zone-section";

--- a/apps/frontend/app/marketplace/[id]/page.tsx
+++ b/apps/frontend/app/marketplace/[id]/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { Navbar } from "@/components/landing/Navbar";
 import { Footer } from "@/components/landing/Footer";
+
+export const metadata: Metadata = {
+  title: "Campaign Details — AdsBazaar",
+};
 import { campaignDetailMock } from "@/components/marketplace/campaign-detail-data";
 import { CampaignDetailHeader } from "@/components/marketplace/campaign-detail-header";
 import { CampaignHeroImage } from "@/components/marketplace/campaign-hero-image";

--- a/apps/frontend/app/marketplace/page.tsx
+++ b/apps/frontend/app/marketplace/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { Navbar } from "@/components/landing/Navbar";
 import { Footer } from "@/components/landing/Footer";
+
+export const metadata: Metadata = {
+  title: "Marketplace — AdsBazaar",
+};
 import { MarketplaceHero } from "@/components/marketplace/marketplace-hero";
 import { MarketplaceFilters } from "@/components/marketplace/marketplace-filters";
 import { MarketplaceGridHeader } from "@/components/marketplace/marketplace-grid-header";


### PR DESCRIPTION
### Summary
This PR configures page-specific browser tab titles across all dashboard views and marketplace pages. Previously, the app fell back to a generic name for almost all views.

### Changes Made

#### 1. Dashboard Layout Templates
Added title templates with fallback defaults to ensure dynamic page titles conform to the specified structures:
- `apps/frontend/app/dashboard/creator/layout.tsx`: `"%s — AdsBazaar Creator"`
- `apps/frontend/app/dashboard/business/layout.tsx`: `"%s — AdsBazaar Business"`

#### 2. Page-Specific Metadata
Added metadata exports to the Server Component pages to customize browser titles:
- `apps/frontend/app/dashboard/creator/analytics/page.tsx` ➔ `"Analytics"`
- `apps/frontend/app/dashboard/creator/inventory/page.tsx` ➔ `"Inventory"`
- `apps/frontend/app/dashboard/creator/payouts/page.tsx` ➔ `"Payouts"`
- `apps/frontend/app/dashboard/creator/settings/page.tsx` ➔ `"Settings"`
- `apps/frontend/app/dashboard/business/analytics/page.tsx` ➔ `"Analytics"`
- `apps/frontend/app/dashboard/business/payouts/page.tsx` ➔ `"Payouts"`
- `apps/frontend/app/dashboard/business/settings/page.tsx` ➔ `"Settings"`
- `apps/frontend/app/marketplace/page.tsx` ➔ `"Marketplace — AdsBazaar"`
- `apps/frontend/app/marketplace/[id]/page.tsx` ➔ `"Campaign Details — AdsBazaar"`

---

### Verification
Ran `pnpm --filter frontend build` in the workspace root, which completed successfully:
- Compiling, type-checking, and static generation of all 18 routes completed without errors.

### Checklist
- [x] Unique browser titles defined for dashboard layouts
- [x] Individual dashboard pages export metadata title overrides
- [x] Marketplace pages updated with dedicated metadata
- [x] Frontend successfully compiles with `pnpm --filter frontend build`

Closes #82 