### PR TITLE
feat: add campaign creator avatar row to business overview stat area

### DIFF
--- a/apps/frontend/app/dashboard/business/page.tsx
+++ b/apps/frontend/app/dashboard/business/page.tsx
@@ -30,8 +30,16 @@ export default function BusinessDashboardPage() {
           align="center"
           label="Active Campaigns"
           value={businessMetrics.activeCampaigns.value}
-          delta={businessMetrics.activeCampaigns.sub}
-        />
+        >
+          <div className="mt-2 flex flex-wrap items-center justify-center -space-x-1.5">
+            <div className="size-5 rounded-full border-2 border-[var(--dash-surface)] bg-[var(--dash-border)]" />
+            <div className="size-5 rounded-full border-2 border-[var(--dash-surface)] bg-[var(--dash-muted)]" />
+            <div className="size-5 rounded-full border-2 border-[var(--dash-surface)] bg-[var(--dash-body)]" />
+            <div className="flex size-5 items-center justify-center rounded-full border-2 border-[var(--dash-surface)] bg-[var(--dash-accent)] text-[8px] font-bold text-[var(--dash-on-accent)]">
+              +14
+            </div>
+          </div>
+        </StatCard>
 
         <StatCard
           className="col-span-12 sm:col-span-6 lg:col-span-3"

--- a/apps/frontend/components/dashboard/creator/stat-card.tsx
+++ b/apps/frontend/components/dashboard/creator/stat-card.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 
 type StatCardProps = {
   align?: "center" | "start";
+  children?: ReactNode;
   className?: string;
   delta?: string;
   icon?: LucideIcon;
@@ -12,6 +14,7 @@ type StatCardProps = {
 
 export function StatCard({
   align = "start",
+  children,
   className = "",
   delta,
   icon: Icon,
@@ -56,6 +59,8 @@ export function StatCard({
       {delta ? (
         <p className="mt-1 text-sm text-[var(--dash-muted)]">{delta}</p>
       ) : null}
+
+      {children}
     </article>
   );
 }


### PR DESCRIPTION
## feat: Add campaign creator avatar row to business dashboard overview stat area

Closes #94

### Problem
The business dashboard overview's "Active Campaigns" stat card originally showed a row of creator profile circles with a "+14" overflow indicator. This was lost during the redesign when the card switched to the generic `StatCard`, which supported only `delta` text — not avatar rows.

### What changed
- **`StatCard`** — added an optional `children` slot for custom sub-content, rendered below the value/delta. Non-breaking; all other cards are unaffected.
- **Business overview** — the Active Campaigns card now renders 3 creator avatar placeholder circles + a `+14` overflow badge via the new slot, replacing the prior sub-text.
