### PR TITLE
feat: filter explore trending campaigns by hashtag

### DIFF
--- a/apps/frontend/app/explore/layout.tsx
+++ b/apps/frontend/app/explore/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "Explore — AdsBazaar",
+  description:
+    "Discover trending campaigns, market insights, and top-rated creators across the AdsBazaar ecosystem.",
+};
+
+export default function ExploreLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/frontend/app/explore/page.tsx
+++ b/apps/frontend/app/explore/page.tsx
@@ -1,23 +1,42 @@
+"use client";
+
+import { useMemo, useState } from "react";
 import { Navbar } from "@/components/landing/Navbar";
 import { Footer } from "@/components/landing/Footer";
 import { ExploreHero } from "@/components/explore/explore-hero";
 import { TrendingCampaigns } from "@/components/explore/trending-campaigns";
 import { MarketInsights } from "@/components/explore/market-insights";
 import { TopCreators } from "@/components/explore/top-creators";
-
-export const metadata = {
-  title: "Explore — AdsBazaar",
-  description:
-    "Discover trending campaigns, market insights, and top-rated creators across the AdsBazaar ecosystem.",
-};
+import {
+  trendingCampaigns,
+  type TrendingCampaignCategory,
+} from "@/components/explore/explore-data";
 
 export default function ExplorePage() {
+  const [activeTag, setActiveTag] = useState<TrendingCampaignCategory | null>(
+    null
+  );
+
+  const filteredCampaigns = useMemo(() => {
+    if (!activeTag) {
+      return trendingCampaigns;
+    }
+
+    return trendingCampaigns.filter(
+      (campaign) => campaign.category === activeTag
+    );
+  }, [activeTag]);
+
+  function handleTagClick(category: TrendingCampaignCategory) {
+    setActiveTag((currentTag) => (currentTag === category ? null : category));
+  }
+
   return (
     <>
       <Navbar />
       <main className="max-w-[1280px] mx-auto px-6 lg:px-10 pt-28 pb-20">
-        <ExploreHero />
-        <TrendingCampaigns />
+        <ExploreHero activeTag={activeTag} onTagClick={handleTagClick} />
+        <TrendingCampaigns campaigns={filteredCampaigns} />
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-12">
           <MarketInsights />
           <TopCreators />

--- a/apps/frontend/components/explore/explore-data.ts
+++ b/apps/frontend/components/explore/explore-data.ts
@@ -1,4 +1,10 @@
 export type TrendingCampaignTag = "hot" | "featured";
+export type TrendingCampaignCategory =
+  | "stellar"
+  | "gaming"
+  | "fintech"
+  | "creator"
+  | "defi";
 
 export type TrendingCampaignItem = {
   id: string;
@@ -6,7 +12,13 @@ export type TrendingCampaignItem = {
   description: string;
   budget: string;
   tag: TrendingCampaignTag | null;
+  category: TrendingCampaignCategory;
   iconBg: string; // Tailwind bg class for the icon box
+};
+
+export type HashtagPill = {
+  label: string;
+  category: TrendingCampaignCategory;
 };
 
 export type InsightRow = {
@@ -26,12 +38,12 @@ export type CreatorCard = {
   avatarPath: string;
 };
 
-export const hashtagPills = [
-  "#StellarSummer",
-  "#Web3Gaming",
-  "#FintechReach",
-  "#CreatorEconomy",
-  "#DeFiSocial",
+export const hashtagPills: HashtagPill[] = [
+  { label: "#StellarSummer", category: "stellar" },
+  { label: "#Web3Gaming", category: "gaming" },
+  { label: "#FintechReach", category: "fintech" },
+  { label: "#CreatorEconomy", category: "creator" },
+  { label: "#DeFiSocial", category: "defi" },
 ];
 
 export const trendingCampaigns: TrendingCampaignItem[] = [
@@ -42,6 +54,7 @@ export const trendingCampaigns: TrendingCampaignItem[] = [
       "Promote the first decentralized yield aggregator on Stellar with native Soroban integration.",
     budget: "12.5k XLM",
     tag: "hot",
+    category: "fintech",
     iconBg: "bg-blue-900/40",
   },
   {
@@ -51,6 +64,7 @@ export const trendingCampaigns: TrendingCampaignItem[] = [
       "Top-tier gaming creators needed for the largest RPG tournament on the Stellar network.",
     budget: "50.0k XLM",
     tag: "featured",
+    category: "gaming",
     iconBg: "bg-red-900/40",
   },
   {
@@ -60,6 +74,7 @@ export const trendingCampaigns: TrendingCampaignItem[] = [
       "Educational series about Stellar energy consumption and sustainable validation.",
     budget: "8.2k XLM",
     tag: null,
+    category: "stellar",
     iconBg: "bg-green-900/40",
   },
 ];

--- a/apps/frontend/components/explore/explore-hero.tsx
+++ b/apps/frontend/components/explore/explore-hero.tsx
@@ -1,6 +1,11 @@
-import { hashtagPills } from "./explore-data";
+import { hashtagPills, type TrendingCampaignCategory } from "./explore-data";
 
-export function ExploreHero() {
+type ExploreHeroProps = {
+  activeTag: TrendingCampaignCategory | null;
+  onTagClick: (category: TrendingCampaignCategory) => void;
+};
+
+export function ExploreHero({ activeTag, onTagClick }: ExploreHeroProps) {
   return (
     <section>
       <h1 className="font-sora text-[48px] lg:text-[64px] font-[900] italic text-on-surface text-center leading-[1.05] max-w-[700px] mx-auto">
@@ -9,11 +14,17 @@ export function ExploreHero() {
       <div className="flex flex-wrap justify-center gap-3 mt-8">
         {hashtagPills.map((pill) => (
           <button
-            key={pill}
+            key={pill.category}
             type="button"
-            className="border border-outline-variant bg-surface-container-high px-4 py-2 text-sm font-semibold text-on-surface-variant hover:border-primary-container hover:text-primary-container transition-colors cursor-pointer"
+            onClick={() => onTagClick(pill.category)}
+            aria-pressed={activeTag === pill.category}
+            className={`border border-outline-variant px-4 py-2 text-sm font-semibold transition-colors cursor-pointer ${
+              activeTag === pill.category
+                ? "bg-primary-container text-on-primary"
+                : "bg-surface-container-high text-on-surface-variant hover:border-primary-container hover:text-primary-container"
+            }`}
           >
-            {pill}
+            {pill.label}
           </button>
         ))}
       </div>

--- a/apps/frontend/components/explore/trending-campaigns.tsx
+++ b/apps/frontend/components/explore/trending-campaigns.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { trendingCampaigns } from "./explore-data";
+import type { TrendingCampaignItem } from "./explore-data";
 import { TrendingCampaignCard } from "./trending-campaign-card";
 
-export function TrendingCampaigns() {
+type TrendingCampaignsProps = {
+  campaigns: TrendingCampaignItem[];
+};
+
+export function TrendingCampaigns({ campaigns }: TrendingCampaignsProps) {
   return (
     <section>
       <div className="flex items-end justify-between mt-16 mb-6">
@@ -23,13 +27,19 @@ export function TrendingCampaigns() {
         </a>
       </div>
 
-      <div className="flex gap-5 overflow-x-auto pb-4 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        {trendingCampaigns.map((campaign) => (
-          <div key={campaign.id} className="snap-start shrink-0 w-[300px]">
-            <TrendingCampaignCard campaign={campaign} />
-          </div>
-        ))}
-      </div>
+      {campaigns.length > 0 ? (
+        <div className="flex gap-5 overflow-x-auto pb-4 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {campaigns.map((campaign) => (
+            <div key={campaign.id} className="snap-start shrink-0 w-[300px]">
+              <TrendingCampaignCard campaign={campaign} />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="border border-outline-variant bg-surface-container p-6 text-sm font-medium text-on-surface-variant">
+          No trending campaigns match this hashtag yet.
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Adds click filtering for the Explore page hashtag pills so they control the Trending Campaigns section.

## Changes

- Add typed hashtag categories and campaign `category` values.
- Lift `activeTag` state into the Explore page and pass it to `ExploreHero`.
- Highlight the active hashtag pill with `bg-primary-container text-on-primary`.
- Pass filtered campaign data into `TrendingCampaigns`.
- Toggle the active pill off to restore the all-campaign view.
- Preserve the Explore route metadata through a route-local layout.

## Testing/Verification

- `apps/frontend/node_modules/.bin/tsc.cmd --project apps/frontend/tsconfig.json --noEmit`
- `apps/frontend/node_modules/.bin/next.cmd build --webpack --debug-build-paths app/explore/page.tsx`
- Playwright CLI smoke on `/explore`: verified all-campaign initial state, `#Web3Gaming` filtering, toggle-off restore, empty category fallback, and `Explore — AdsBazaar` page title.

Note: full frontend build is currently blocked by an unrelated existing Next 16 generated type error in `app/dashboard/business/campaigns/[id]/page.ts`; the Explore route builds cleanly with `--debug-build-paths`.

