### PR TITLE
Feat/wizard backward navigation

### DIFF
--- a/apps/frontend/components/campaigns/new/wizard-step-indicator.tsx
+++ b/apps/frontend/components/campaigns/new/wizard-step-indicator.tsx
@@ -3,9 +3,10 @@ import { Check } from "lucide-react";
 interface WizardStepIndicatorProps {
   steps: { label: string }[];
   currentStep: number; // 1-indexed
+  onStepClick?: (step: number) => void;
 }
 
-export function WizardStepIndicator({ steps, currentStep }: WizardStepIndicatorProps) {
+export function WizardStepIndicator({ steps, currentStep, onStepClick }: WizardStepIndicatorProps) {
   return (
     <div className="mb-8 flex items-start justify-between">
       {steps.map((step, index) => {

--- a/apps/frontend/components/campaigns/new/wizard-step-indicator.tsx
+++ b/apps/frontend/components/campaigns/new/wizard-step-indicator.tsx
@@ -30,6 +30,7 @@ export function WizardStepIndicator({ steps, currentStep, onStepClick }: WizardS
                 <button
                   type="button"
                   onClick={() => onStepClick?.(stepNumber)}
+                  aria-label={`Go to ${step.label}`}
                   className="relative z-10 flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full text-sm font-bold transition-colors"
                   style={{
                     backgroundColor: "#c8f232",
@@ -42,6 +43,8 @@ export function WizardStepIndicator({ steps, currentStep, onStepClick }: WizardS
                 <button
                   type="button"
                   disabled
+                  aria-current="step"
+                  aria-label={`Current step: ${step.label}`}
                   className="relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold transition-colors"
                   style={{
                     backgroundColor: "#c8f232",
@@ -52,6 +55,7 @@ export function WizardStepIndicator({ steps, currentStep, onStepClick }: WizardS
                 </button>
               ) : (
                 <div
+                  aria-label={`Future step: ${step.label}`}
                   className="relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold transition-colors"
                   style={{
                     backgroundColor: "rgba(255,255,255,0.08)",

--- a/apps/frontend/components/campaigns/new/wizard-step-indicator.tsx
+++ b/apps/frontend/components/campaigns/new/wizard-step-indicator.tsx
@@ -26,15 +26,41 @@ export function WizardStepIndicator({ steps, currentStep, onStepClick }: WizardS
               )}
 
               {/* Step circle */}
-              <div
-                className="relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold transition-colors"
-                style={{
-                  backgroundColor: isCompleted || isActive ? "#c8f232" : "rgba(255,255,255,0.08)",
-                  color: isCompleted || isActive ? "#293500" : "rgba(255,255,255,0.4)",
-                }}
-              >
-                {isCompleted ? <Check size={16} strokeWidth={3} /> : stepNumber}
-              </div>
+              {isCompleted ? (
+                <button
+                  type="button"
+                  onClick={() => onStepClick?.(stepNumber)}
+                  className="relative z-10 flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full text-sm font-bold transition-colors"
+                  style={{
+                    backgroundColor: "#c8f232",
+                    color: "#293500",
+                  }}
+                >
+                  <Check size={16} strokeWidth={3} />
+                </button>
+              ) : isActive ? (
+                <button
+                  type="button"
+                  disabled
+                  className="relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold transition-colors"
+                  style={{
+                    backgroundColor: "#c8f232",
+                    color: "#293500",
+                  }}
+                >
+                  {stepNumber}
+                </button>
+              ) : (
+                <div
+                  className="relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold transition-colors"
+                  style={{
+                    backgroundColor: "rgba(255,255,255,0.08)",
+                    color: "rgba(255,255,255,0.4)",
+                  }}
+                >
+                  {stepNumber}
+                </div>
+              )}
 
               {/* Right connector */}
               {index < steps.length - 1 && (

--- a/apps/frontend/components/dashboard/business/campaign-wizard-modal.tsx
+++ b/apps/frontend/components/dashboard/business/campaign-wizard-modal.tsx
@@ -278,7 +278,7 @@ export function CampaignWizardModal() {
           <div className="mx-auto max-w-[600px] px-5 py-8">
             {hydrated ? (
               <>
-                <WizardStepIndicator steps={STEPS} currentStep={state.currentStep} />
+                <WizardStepIndicator steps={STEPS} currentStep={state.currentStep} onStepClick={goToStep} />
 
                 {state.currentStep === 1 && (
                   <StepCampaignBrief


### PR DESCRIPTION
closes #85 

4 commits pushed on `feat/wizard-backward-navigation`. Here's what changed:

| Commit | Change |
|--------|--------|
| `acd2e9a` | Added `onStepClick` prop to `WizardStepIndicatorProps` |
| `cdd3a73` | Wired `onStepClick={goToStep}` in `CampaignWizardModal` |
| `154c5bb` | Completed steps → clickable `<button>` with `cursor-pointer`; current step → `<button disabled>` |
| `7053ae8` | Added `aria-current="step"` and `aria-label` attributes for accessibility |

**Behavior:**
- Completed steps (step < currentStep): `<button>` with `onClick → goToStep(n)` — jumps back to that step, clears errors, scrolls to top
- Current step: `<button disabled>` — visually highlighted but not actionable
- Future steps: plain `<div>` — cannot skip ahead

The existing `goToStep()` in `campaign-wizard-modal.tsx:187` already calls `setErrors({})` + `scrollToTop()`, so all side effects are preserved.