### PR TITLE
fix(frontend): replace hardcoded wallet address with dynamic useWallet context in campaign review step

### DIFF
--- a/apps/frontend/components/campaigns/new/steps/step-review-fund.tsx
+++ b/apps/frontend/components/campaigns/new/steps/step-review-fund.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Globe, Users, LayoutGrid, CheckCircle2 } from "lucide-react";
+import { useWallet } from "@/components/wallet/wallet-context";
 
 interface WizardState {
   brief: {
@@ -39,7 +40,12 @@ interface StepReviewFundProps {
 }
 
 export function StepReviewFund({ data, onGoToStep }: StepReviewFundProps) {
+  const { wallet } = useWallet();
   const { brief, targeting, budget, proof } = data;
+
+  const walletDisplay = wallet
+    ? `${wallet.address.slice(0, 4)}...${wallet.address.slice(-4)}`
+    : "No wallet connected";
 
   const creatorPool = budget.totalBudget;
   const platformFee = budget.totalBudget * 0.005;
@@ -229,7 +235,7 @@ export function StepReviewFund({ data, onGoToStep }: StepReviewFundProps) {
         </div>
 
         <div className="mt-5 flex items-center justify-between border-t border-[rgba(255,255,255,0.08)] pt-4">
-          <span className="font-mono text-[13px] text-[rgba(255,255,255,0.35)]">GC4C...7R4A</span>
+          <span className="font-mono text-[13px] text-[rgba(255,255,255,0.35)]">{walletDisplay}</span>
           <span className="text-[12px] text-[rgba(255,255,255,0.35)]">Stellar Mainnet</span>
         </div>
       </div>


### PR DESCRIPTION
## Description
Replaced the hardcoded wallet address (`GC4C...7R4A`) in the final campaign wizard review step (`StepReviewFund`) with the real connected wallet address using the existing `useWallet` context.

## Changes
- Integrated `useWallet` hook into `step-review-fund.tsx`.
- Handled `WalletState | null` reactively to provide a safe fallback when no wallet is active.
- Truncated the public key to follow the standard format (`slice(0, 4)...slice(-4)`).
- Verified clean TypeScript compilation via `tsc --noEmit`.

## Evidence (Proof of Work)

### Connected Wallet 
Artifact showing the dynamic integration of the real connected wallet (`GDQJ...VMCW`):

<img width="1893" height="977" alt="adsBazaar" src="https://github.com/user-attachments/assets/42d51590-c80c-4879-beb5-52db5e8ce811">

Any feedback is welcome, thanksss!!!

closes #75 