### PR TITLE
feat(frontend): fix #91 by adding disabled states and 'Coming soon' tooltips to creator inventory buttons

### DIFF
--- a/apps/frontend/components/dashboard/creator/connected-channels.tsx
+++ b/apps/frontend/components/dashboard/creator/connected-channels.tsx
@@ -47,10 +47,12 @@ function ChannelCard({ channel }: { channel: ConnectedChannel }) {
 
       <button
         type="button"
+        disabled
+        title="Coming soon"
         className={
           isActive
-            ? "mt-auto w-full border border-[var(--dash-border)] py-2 text-sm font-bold text-[var(--dash-heading)] transition-colors hover:bg-[var(--dash-border)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
-            : "mt-auto w-full bg-[var(--dash-accent-strong)] py-2 text-sm font-bold text-[var(--dash-on-accent-strong)] transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+            ? "mt-auto w-full border border-[var(--dash-border)] py-2 text-sm font-bold text-[var(--dash-heading)] transition-colors hover:bg-[var(--dash-border)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] disabled:cursor-not-allowed disabled:opacity-60"
+            : "mt-auto w-full bg-[var(--dash-accent-strong)] py-2 text-sm font-bold text-[var(--dash-on-accent-strong)] transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] disabled:cursor-not-allowed disabled:opacity-60"
         }
       >
         {isActive ? "Manage Account" : "Reconnect Token"}
@@ -85,6 +87,7 @@ export function ConnectedChannels({
         <button
           type="button"
           disabled
+          title="Coming soon"
           className="flex min-h-[160px] flex-col items-center justify-center gap-2 bg-black border border-dashed border-gray-600 p-4 text-center disabled:cursor-not-allowed disabled:opacity-60"
         >
           <div className="flex flex-col items-center justify-center gap-2 border border-dashed border-gray-600">

--- a/apps/frontend/components/dashboard/creator/digital-media-kit.tsx
+++ b/apps/frontend/components/dashboard/creator/digital-media-kit.tsx
@@ -35,7 +35,9 @@ export function DigitalMediaKit({ mediaKit }: { mediaKit: MediaKit }) {
         </h2>
         <button
           type="button"
-          className="text-xs font-bold text-[var(--dash-accent)] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)]"
+          disabled
+          title="Coming soon"
+          className="text-xs font-bold text-[var(--dash-accent)] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dash-accent)] disabled:cursor-not-allowed disabled:opacity-60"
         >
           Edit Info
         </button>


### PR DESCRIPTION
closes #91 
This PR addresses issue #91 where multiple buttons on the creator inventory page were silently non-functional when clicked. This lack of feedback felt broken to users. 
We have updated the "Manage Account" and "Reconnect Token" buttons, the "Link New Platform" card, and the "Edit Info" button in the Digital Media Kit section to explicitly display a disabled state. The update includes a native `title="Coming soon"` tooltip and standard TailwindCSS disabled visual styles (`disabled:cursor-not-allowed disabled:opacity-60`), providing users with immediate feedback that these features are currently in development.

# Changes Made
- Added `disabled` attribute to "Manage Account", "Reconnect Token", and "Edit Info" buttons.
- Added `title="Coming soon"` tooltips to the aforementioned buttons as well as the "Link New Platform" card.
- Appended `disabled:cursor-not-allowed disabled:opacity-60` to the class lists for "Manage Account", "Reconnect Token", and "Edit Info" buttons in `connected-channels.tsx` and `digital-media-kit.tsx`.

# Testing
No automated test suite changes were required for this CSS and HTML attribute update. Manual verification was performed locally:
- Verified all targeted buttons display the "Coming soon" tooltip on hover.
- Verified visual transparency (`opacity-60`) and `not-allowed` cursor behavior.
- Confirmed buttons can no longer be focused or clicked.