### PR TITLE
fix: add notification bell and wallet parity to mobile navbar drawer

### DIFF
--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import { WalletProvider } from "@/components/wallet/wallet-provider";
 import { RoleProvider } from "@/components/role/role-context";
 import { OnboardingModalProvider } from "@/components/onboarding/onboarding-modal-context";
 import { OnboardingWizardModal } from "@/components/onboarding/onboarding-wizard-modal";
+import { NotificationProvider } from "@/components/notifications/notification-context";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -41,14 +42,16 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${sora.variable} antialiased`}
       >
-        <WalletProvider>
-          <RoleProvider>
-            <OnboardingModalProvider>
-              {children}
-              <OnboardingWizardModal />
-            </OnboardingModalProvider>
-          </RoleProvider>
-        </WalletProvider>
+        <NotificationProvider>
+          <WalletProvider>
+            <RoleProvider>
+              <OnboardingModalProvider>
+                {children}
+                <OnboardingWizardModal />
+              </OnboardingModalProvider>
+            </RoleProvider>
+          </WalletProvider>
+        </NotificationProvider>
       </body>
     </html>
   );

--- a/apps/frontend/components/dashboard/creator/campaigns-page-header.tsx
+++ b/apps/frontend/components/dashboard/creator/campaigns-page-header.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { Search, Bell } from "lucide-react"
+import { Search } from "lucide-react"
 import { WalletChip } from "@/components/wallet/wallet-chip"
+import { NotificationBell } from "@/components/notifications/notification-bell"
 
 interface CampaignsPageHeaderProps {
   searchValue: string
@@ -26,13 +27,7 @@ export function CampaignsPageHeader({
       </div>
 
       <div className="flex shrink-0 items-center gap-3">
-        <button
-          type="button"
-          aria-label="Notifications"
-          className="flex size-11 items-center justify-center rounded text-[var(--dash-muted)] transition-colors hover:text-[var(--dash-heading)]"
-        >
-          <Bell className="size-5" />
-        </button>
+        <NotificationBell variant="dashboard" />
         <div className="hidden lg:block">
           <WalletChip />
         </div>

--- a/apps/frontend/components/landing/Navbar.tsx
+++ b/apps/frontend/components/landing/Navbar.tsx
@@ -79,23 +79,32 @@ export function Navbar() {
 
       {/* Mobile Drawer */}
       {isMobileMenuOpen && (
-        <div className="md:hidden bg-surface-container border-b border-outline-variant px-6 py-4 flex flex-col gap-4">
+        <div className="md:hidden overflow-visible bg-surface-container border-b border-outline-variant px-6 py-4 flex flex-col gap-4">
           <a
             href="/marketplace"
             className="text-[15px] text-on-surface py-2 font-medium"
+            onClick={() => setIsMobileMenuOpen(false)}
           >
             Marketplace
           </a>
           <a
             href="/explore"
             className="text-[15px] text-on-surface-variant py-2"
+            onClick={() => setIsMobileMenuOpen(false)}
           >
             Explore
           </a>
-          <a href="/stats" className="text-[15px] text-on-surface-variant py-2">
+          <a
+            href="/stats"
+            className="text-[15px] text-on-surface-variant py-2"
+            onClick={() => setIsMobileMenuOpen(false)}
+          >
             Stats
           </a>
-          <ConnectWalletButton />
+          <div className="flex items-center justify-between gap-3 pt-2 border-t border-outline-variant mt-2">
+            <NotificationBell variant="landing" />
+            <ConnectWalletButton />
+          </div>
         </div>
       )}
     </nav>

--- a/apps/frontend/components/landing/Navbar.tsx
+++ b/apps/frontend/components/landing/Navbar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Bell, Menu, X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { ConnectWalletButton } from "@/components/wallet/connect-wallet-button";
+import { NotificationBell } from "@/components/notifications/notification-bell";
 
 export function Navbar() {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -56,12 +57,7 @@ export function Navbar() {
 
         {/* Actions */}
         <div className="hidden md:flex items-center gap-6">
-          <button
-            aria-label="Notifications"
-            className="text-on-surface-variant hover:text-on-surface transition-colors"
-          >
-            <Bell className="w-5 h-5" />
-          </button>
+          <NotificationBell variant="landing" />
           <ConnectWalletButton />
         </div>
 

--- a/apps/frontend/components/notifications/notification-bell.tsx
+++ b/apps/frontend/components/notifications/notification-bell.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Bell, Check } from "lucide-react";
+import { useNotifications, type Notification } from "./notification-context";
+
+export type NotificationBellVariant = "landing" | "dashboard";
+
+type VariantClasses = {
+  button: string;
+  buttonHover: string;
+  badgeText: string;
+  panel: string;
+  panelHeaderBorder: string;
+  panelHeaderTitle: string;
+  markAllRead: string;
+  markAllReadHover: string;
+  item: string;
+  itemBorder: string;
+  itemHover: string;
+  itemUnreadBg: string;
+  itemRead: string;
+  itemUnread: string;
+  itemTitle: string;
+  itemDescription: string;
+  itemTime: string;
+  unreadDot: string;
+  empty: string;
+};
+
+const LANDING_VARIANT: VariantClasses = {
+  button: "relative text-on-surface-variant",
+  buttonHover: "hover:text-on-surface",
+  badgeText: "text-[#293500]",
+  panel: "bg-surface-container border-outline-variant",
+  panelHeaderBorder: "border-outline-variant",
+  panelHeaderTitle: "text-on-surface",
+  markAllRead: "text-on-surface-variant",
+  markAllReadHover: "hover:text-on-surface",
+  item: "bg-surface-container",
+  itemBorder: "border-outline-variant",
+  itemHover: "hover:bg-surface-container-high",
+  itemUnreadBg: "bg-primary-container/10",
+  itemRead: "text-on-surface-variant",
+  itemUnread: "text-on-surface",
+  itemTitle: "text-on-surface",
+  itemDescription: "text-on-surface-variant",
+  itemTime: "text-on-surface-variant",
+  unreadDot: "bg-primary-container",
+  empty: "text-on-surface-variant",
+};
+
+const DASHBOARD_VARIANT: VariantClasses = {
+  button:
+    "relative flex size-11 items-center justify-center rounded text-[var(--dash-muted)]",
+  buttonHover:
+    "hover:text-[var(--dash-heading)] hover:bg-[var(--dash-surface)]",
+  badgeText: "text-[var(--dash-on-accent-strong)]",
+  panel: "bg-[var(--dash-surface)] border-[var(--dash-border)]",
+  panelHeaderBorder: "border-[var(--dash-border)]",
+  panelHeaderTitle: "text-[var(--dash-heading)]",
+  markAllRead: "text-[var(--dash-muted)]",
+  markAllReadHover: "hover:text-[var(--dash-heading)]",
+  item: "bg-[var(--dash-surface)]",
+  itemBorder: "border-[var(--dash-border)]",
+  itemHover: "hover:bg-[var(--dash-bg)]",
+  itemUnreadBg: "bg-[var(--dash-bg)]",
+  itemRead: "text-[var(--dash-muted)]",
+  itemUnread: "text-[var(--dash-heading)]",
+  itemTitle: "text-[var(--dash-heading)]",
+  itemDescription: "text-[var(--dash-muted)]",
+  itemTime: "text-[var(--dash-muted)]",
+  unreadDot: "bg-[var(--dash-accent-strong)]",
+  empty: "text-[var(--dash-muted)]",
+};
+
+const VARIANTS: Record<NotificationBellVariant, VariantClasses> = {
+  landing: LANDING_VARIANT,
+  dashboard: DASHBOARD_VARIANT,
+};
+
+type NotificationItemProps = {
+  notification: Notification;
+  variant: NotificationBellVariant;
+  onSelect: (id: string) => void;
+};
+
+function NotificationItem({
+  notification,
+  variant,
+  onSelect,
+}: NotificationItemProps) {
+  const v = VARIANTS[variant];
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(notification.id)}
+        aria-label={`Notification: ${notification.title}`}
+        className={`flex w-full items-start gap-3 rounded border p-3 text-left transition-colors ${v.itemBorder} ${v.item} ${v.itemHover} ${
+          notification.read ? v.itemRead : v.itemUnread
+        } ${!notification.read ? v.itemUnreadBg : ""}`}
+      >
+        <span
+          aria-hidden="true"
+          className={`mt-1.5 size-2 shrink-0 rounded-full ${
+            notification.read ? "bg-transparent" : v.unreadDot
+          }`}
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-semibold leading-snug">
+            <span className={v.itemTitle}>{notification.title}</span>
+          </span>
+          <span
+            className={`mt-0.5 block text-[13px] leading-snug ${v.itemDescription}`}
+          >
+            {notification.description}
+          </span>
+          <span
+            className={`mt-1 block text-[11px] uppercase tracking-wide ${v.itemTime}`}
+          >
+            {notification.time}
+          </span>
+        </span>
+      </button>
+    </li>
+  );
+}
+
+export type NotificationBellProps = {
+  variant: NotificationBellVariant;
+  className?: string;
+};
+
+export function NotificationBell({ variant, className }: NotificationBellProps) {
+  const { notifications, unreadCount, markAsRead, markAllRead } =
+    useNotifications();
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const v = VARIANTS[variant];
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  const buttonSize = variant === "landing" ? "p-1.5" : "size-11";
+
+  return (
+    <div ref={containerRef} className={`relative ${className ?? ""}`}>
+      <button
+        type="button"
+        aria-label={
+          unreadCount > 0
+            ? `Notifications, ${unreadCount} unread`
+            : "Notifications"
+        }
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((prev) => !prev)}
+        className={`${buttonSize} transition-colors ${v.button} ${v.buttonHover}`}
+      >
+        <Bell className="size-5" aria-hidden="true" />
+        {unreadCount > 0 && (
+          <span
+            aria-hidden="true"
+            className={`absolute right-1 top-1 inline-flex min-w-[18px] items-center justify-center rounded-full bg-[var(--db-danger,#ff5470)] px-1 text-[10px] font-bold leading-[14px] ${v.badgeText}`}
+          >
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          role="dialog"
+          aria-label="Notifications"
+          className={`absolute right-0 top-full z-50 mt-2 w-[320px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border shadow-xl ${v.panel}`}
+        >
+          <div
+            className={`flex items-center justify-between border-b px-4 py-3 ${v.panelHeaderBorder}`}
+          >
+            <h3
+              className={`text-sm font-semibold uppercase tracking-wide ${v.panelHeaderTitle}`}
+            >
+              Notifications
+            </h3>
+            <button
+              type="button"
+              onClick={markAllRead}
+              disabled={unreadCount === 0}
+              className={`flex items-center gap-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${v.markAllRead} ${v.markAllReadHover}`}
+            >
+              <Check className="size-3.5" aria-hidden="true" />
+              Mark all read
+            </button>
+          </div>
+
+          {notifications.length === 0 ? (
+            <p className={`px-4 py-6 text-center text-sm ${v.empty}`}>
+              You're all caught up.
+            </p>
+          ) : (
+            <ul className="flex max-h-[400px] flex-col gap-2 overflow-y-auto p-3">
+              {notifications.map((notification) => (
+                <NotificationItem
+                  key={notification.id}
+                  notification={notification}
+                  variant={variant}
+                  onSelect={(id) => {
+                    markAsRead(id);
+                  }}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/notifications/notification-context.tsx
+++ b/apps/frontend/components/notifications/notification-context.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type NotificationType = "campaign" | "payout" | "system";
+
+export type Notification = {
+  id: string;
+  title: string;
+  description: string;
+  time: string;
+  read: boolean;
+  type: NotificationType;
+};
+
+export type NotificationContextValue = {
+  notifications: Notification[];
+  unreadCount: number;
+  markAsRead: (id: string) => void;
+  markAllRead: () => void;
+};
+
+const STORAGE_KEY = "adsbazaar_notification_read_state";
+
+const INITIAL_NOTIFICATIONS: Notification[] = [
+  {
+    id: "n1",
+    title: "New applicant",
+    description: "Alex Rivera applied to your Summer Launch campaign",
+    time: "2 min ago",
+    read: false,
+    type: "campaign",
+  },
+  {
+    id: "n2",
+    title: "Proof submitted",
+    description: "Creator submitted proof for Cyberpunk Rebrand Q4",
+    time: "1 hour ago",
+    read: false,
+    type: "campaign",
+  },
+  {
+    id: "n3",
+    title: "Payout processed",
+    description: "2,500 USDC released to your wallet",
+    time: "3 hours ago",
+    read: true,
+    type: "payout",
+  },
+  {
+    id: "n4",
+    title: "Campaign ending soon",
+    description: "Twitter Alpha Thread expires in 2 days",
+    time: "Yesterday",
+    read: true,
+    type: "system",
+  },
+];
+
+const NotificationContext = createContext<NotificationContextValue | null>(
+  null,
+);
+
+function loadReadIds(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is string => typeof v === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+function saveReadIds(ids: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(ids)));
+  } catch {
+    // Ignore storage failures (private mode, quota, etc.) — UI still works.
+  }
+}
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  // Always start with the seed data so server and client markup match.
+  // We hydrate the read state from sessionStorage in an effect below.
+  const [notifications, setNotifications] =
+    useState<Notification[]>(INITIAL_NOTIFICATIONS);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hydrate read state from sessionStorage on mount.
+  useEffect(() => {
+    const readIds = loadReadIds();
+    if (readIds.size === 0) {
+      setHydrated(true);
+      return;
+    }
+    setNotifications((prev) =>
+      prev.map((n) => (readIds.has(n.id) ? { ...n, read: true } : n)),
+    );
+    setHydrated(true);
+  }, []);
+
+  // Persist read state whenever the notification list changes after hydration.
+  useEffect(() => {
+    if (!hydrated) return;
+    const readIds = new Set(
+      notifications.filter((n) => n.read).map((n) => n.id),
+    );
+    saveReadIds(readIds);
+  }, [notifications, hydrated]);
+
+  const markAsRead = useCallback((id: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+    );
+  }, []);
+
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  }, []);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((n) => !n.read).length,
+    [notifications],
+  );
+
+  const value = useMemo<NotificationContextValue>(
+    () => ({ notifications, unreadCount, markAsRead, markAllRead }),
+    [notifications, unreadCount, markAsRead, markAllRead],
+  );
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications(): NotificationContextValue {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error(
+      "useNotifications must be used within a NotificationProvider",
+    );
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary

- Adds `NotificationBell` and `ConnectWalletButton` to the landing page mobile drawer so it matches the desktop navbar actions row.
- Adds `overflow-visible` on the drawer container so notification and wallet dropdowns are not clipped on small screens.
- Closes the mobile drawer when navigating to Marketplace or Explore.

## Context

This PR is stacked on top of #61 (Issue #58 notification bell). It only changes `Navbar.tsx` in the mobile drawer section. Desktop navbar behavior is unchanged.

Depends on #61.

## Test plan

- [ ] Open `/` at viewport < 768px and tap the hamburger menu
- [ ] Verify notification bell shows unread badge
- [ ] Tap bell and confirm dropdown opens without clipping
- [ ] Connect Freighter and confirm wallet shows network + shortened address in the drawer
- [ ] Tap wallet button and confirm dropdown opens without clipping
- [ ] Confirm desktop navbar (>= 768px) is unchanged

✅ Closes #68 for GrantFox