### PR TITLE
fix: add breadcrumb navigation to marketplace campaign detail page

### DIFF
--- a/apps/frontend/app/marketplace/[id]/page.tsx
+++ b/apps/frontend/app/marketplace/[id]/page.tsx
@@ -13,6 +13,7 @@ import { CampaignRequirements } from "@/components/marketplace/campaign-requirem
 import { EscrowSidebar } from "@/components/marketplace/escrow-sidebar";
 import { ApplicationForm } from "@/components/marketplace/application-form";
 import { CampaignHelpCard } from "@/components/marketplace/campaign-help-card";
+import { Breadcrumb } from "@/components/marketplace/breadcrumb";
 
 export default function CampaignDetailPage({
   params,
@@ -25,7 +26,14 @@ export default function CampaignDetailPage({
     <>
       <Navbar />
       <main className="max-w-[1280px] mx-auto px-6 lg:px-10 pt-28 pb-20">
-        <div className="grid grid-cols-12 gap-8">
+        <Breadcrumb
+          items={[
+            { label: "Marketplace", href: "/marketplace" },
+            { label: campaign.category, href: `/marketplace?category=${encodeURIComponent(campaign.category)}` },
+            { label: campaign.title },
+          ]}
+        />
+        <div className="grid grid-cols-12 gap-8 mt-6">
           <div className="col-span-12 lg:col-span-7 flex flex-col gap-8">
             <CampaignDetailHeader campaign={campaign} />
             <CampaignHeroImage campaign={campaign} />

--- a/apps/frontend/components/marketplace/breadcrumb.tsx
+++ b/apps/frontend/components/marketplace/breadcrumb.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+export type BreadcrumbItem = {
+  label: string;
+  href?: string;
+};
+
+export function Breadcrumb({ items }: { items: BreadcrumbItem[] }) {
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm">
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <span key={index} className="flex items-center gap-1">
+            {index > 0 && (
+              <ChevronRight className="size-4 text-on-surface-variant shrink-0" />
+            )}
+            {!isLast && item.href ? (
+              <Link
+                href={item.href}
+                className="text-on-surface-variant hover:text-on-surface transition-colors"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span
+                className="text-on-surface font-medium"
+                aria-current={isLast ? "page" : undefined}
+              >
+                {item.label}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #80

Adds breadcrumb navigation to the marketplace campaign detail page (`/marketplace/[id]`).

## Changes

- **New:** `components/marketplace/breadcrumb.tsx` — reusable `Breadcrumb` component
  - Accepts `BreadcrumbItem[]` (label + optional href)
  - Accessible: `aria-label="Breadcrumb"` on nav, `aria-current="page"` on last item
  - Uses Next.js `Link` and `lucide-react` `ChevronRight` (existing deps, no new dependencies)

- **Updated:** `app/marketplace/[id]/page.tsx`
  - Renders breadcrumb trail: **Marketplace → Category → Campaign title**
  - Middle item links to category-filtered marketplace

## Testing

- `next build` passes cleanly — TypeScript check + 18 routes compiled, exit 0
closes #105