### PR TITLE
fix: wire MarketplaceCampaignCard into the marketplace grid

### DIFF
--- a/apps/frontend/components/marketplace/marketplace-grid.tsx
+++ b/apps/frontend/components/marketplace/marketplace-grid.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { marketplaceCampaigns } from "./marketplace-data";
+import { MarketplaceCampaignCard } from "./marketplace-campaign-card";
 
 export function MarketplaceGrid() {
   return (
@@ -8,17 +9,9 @@ export function MarketplaceGrid() {
         <Link
           key={campaign.id}
           href={`/marketplace/${campaign.id}`}
-          className="border border-outline-variant bg-surface-container p-5 block hover:border-primary-container transition-colors"
+          className="block"
         >
-          <p className="text-sm font-semibold text-on-surface">
-            {campaign.title}
-          </p>
-          <p className="text-xs text-on-surface-variant mt-1">
-            {campaign.description}
-          </p>
-          <p className="mt-4 font-sora text-lg font-bold text-on-surface">
-            {campaign.payout}
-          </p>
+          <MarketplaceCampaignCard campaign={campaign} />
         </Link>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- **Replaces placeholder `<div>` cards** in `marketplace-grid.tsx` with the existing `MarketplaceCampaignCard` component
- Cards now render status badges (FUNDED / HIGH PRIORITY), payout with currency, deadline in italic, applicant avatars, and CTA buttons (VIEW BRIEF / APPLY NOW)
- High-priority cards get the lime-tinted border via the component's built-in logic

Closes #66

## Changes

**1 file changed:** `apps/frontend/components/marketplace/marketplace-grid.tsx`

- Imported `MarketplaceCampaignCard` from `./marketplace-campaign-card`
- Replaced inline card markup with `<MarketplaceCampaignCard campaign={campaign} />`
- Kept `<Link>` wrapper for navigation to `/marketplace/[id]`

## Acceptance Criteria

- [x] `/marketplace` renders the full `MarketplaceCampaignCard` for each campaign (not placeholder divs)
- [x] Each card shows: icon placeholder, status badge, title, description (line-clamped), payout + currency, deadline, applicant avatars, CTA button
- [x] Cards are clickable and navigate to `/marketplace/[id]`
- [x] High-priority card has lime-tinted border
- [x] TypeScript compiles clean (no new errors)
- [x] Only 1 file changed (`marketplace-grid.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)