### PR TITLE
feat: create network stats stub page and update Navbar links

### DIFF
--- a/apps/frontend/app/stats/page.tsx
+++ b/apps/frontend/app/stats/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import { Navbar } from "@/components/landing/Navbar";
+import { Footer } from "@/components/landing/Footer";
+
+export const metadata: Metadata = {
+  title: "Stats — AdsBazaar",
+  description:
+    "Network statistics and protocol metrics for the AdsBazaar ecosystem.",
+};
+
+export default function StatsPage() {
+  return (
+    <>
+      <Navbar />
+      <main className="max-w-[1280px] mx-auto px-6 lg:px-10 pt-32 pb-20">
+        <div className="flex flex-col items-center justify-center gap-4 py-32 text-center">
+          <h1 className="font-sora text-4xl font-bold text-on-surface">
+            Network Stats
+          </h1>
+          <p className="text-on-surface-variant max-w-md">
+            Protocol metrics, transaction volume, and ecosystem analytics coming
+            soon.
+          </p>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/frontend/components/landing/Navbar.tsx
+++ b/apps/frontend/components/landing/Navbar.tsx
@@ -34,20 +34,32 @@ export function Navbar() {
 
         {/* Desktop Links */}
         <div className="hidden md:flex items-center gap-8">
-          <a href="/marketplace" className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors">
+          <a
+            href="/marketplace"
+            className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors"
+          >
             Marketplace
           </a>
-          <a href="/explore" className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors">
+          <a
+            href="/explore"
+            className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors"
+          >
             Explore
           </a>
-          <a href="#" className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors">
+          <a
+            href="/stats"
+            className="text-[15px] text-on-surface-variant hover:text-on-surface transition-colors"
+          >
             Stats
           </a>
         </div>
 
         {/* Actions */}
         <div className="hidden md:flex items-center gap-6">
-          <button aria-label="Notifications" className="text-on-surface-variant hover:text-on-surface transition-colors">
+          <button
+            aria-label="Notifications"
+            className="text-on-surface-variant hover:text-on-surface transition-colors"
+          >
             <Bell className="w-5 h-5" />
           </button>
           <ConnectWalletButton />
@@ -60,7 +72,11 @@ export function Navbar() {
             aria-label="Toggle menu"
             className="text-on-surface-variant"
           >
-            {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+            {isMobileMenuOpen ? (
+              <X className="w-6 h-6" />
+            ) : (
+              <Menu className="w-6 h-6" />
+            )}
           </button>
         </div>
       </div>
@@ -68,9 +84,21 @@ export function Navbar() {
       {/* Mobile Drawer */}
       {isMobileMenuOpen && (
         <div className="md:hidden bg-surface-container border-b border-outline-variant px-6 py-4 flex flex-col gap-4">
-          <a href="/marketplace" className="text-[15px] text-on-surface py-2 font-medium">Marketplace</a>
-          <a href="/explore" className="text-[15px] text-on-surface-variant py-2">Explore</a>
-          <a href="#" className="text-[15px] text-on-surface-variant py-2">Stats</a>
+          <a
+            href="/marketplace"
+            className="text-[15px] text-on-surface py-2 font-medium"
+          >
+            Marketplace
+          </a>
+          <a
+            href="/explore"
+            className="text-[15px] text-on-surface-variant py-2"
+          >
+            Explore
+          </a>
+          <a href="/stats" className="text-[15px] text-on-surface-variant py-2">
+            Stats
+          </a>
           <ConnectWalletButton />
         </div>
       )}


### PR DESCRIPTION
### What was done
- Created a new minimal stats page stub at `apps/frontend/app/stats/page.tsx` incorporating the `Navbar` and `Footer` components.
- Configured SEO metadata on the `/stats` page.
- Updated the "Stats" link in the desktop and mobile menus of `Navbar.tsx` from pointing to a dead `href="#"` route to pointing to the new `/stats` page.

### Why it was done
- Allows users to navigate to the network stats section from the landing page Navbar without encountering inactive links.

### How it was verified
- Formatted with Prettier to match code style standards.
- Checked that Navbar component links resolve accurately to `/stats`.

closes #77 
