### PR TITLE
fix: replace hardcoded hex colors in landing page sections

### DIFF
--- a/apps/frontend/components/landing/BrandsCreators.tsx
+++ b/apps/frontend/components/landing/BrandsCreators.tsx
@@ -39,34 +39,34 @@ export function BrandsCreators() {
         </div>
 
         {/* Right Column - Creators */}
-        <div className="bg-[#ffffff] p-[32px] md:p-[64px]">
-          <span className="font-geist font-[600] text-[12px] uppercase tracking-[0.05em] text-[#666666] mb-6 block">
+        <div className="bg-white p-[32px] md:p-[64px]">
+          <span className="font-geist font-[600] text-[12px] uppercase tracking-[0.05em] text-[var(--muted-dark)] mb-6 block">
             FOR CREATORS
           </span>
-          <h2 className="font-sora font-[600] text-[32px] text-[#131313] mb-12">
+          <h2 className="font-sora font-[600] text-[32px] text-background mb-12">
             Monetize Your Influence
           </h2>
           
           <div className="flex flex-col gap-10">
             <div className="flex gap-4">
-              <div className="mt-1"><Search className="w-6 h-6 text-[#131313]" /></div>
+              <div className="mt-1"><Search className="w-6 h-6 text-background" /></div>
               <div>
-                <h3 className="font-sora font-[600] text-[18px] text-[#131313] mb-2">Explore Gigs</h3>
-                <p className="font-geist text-[16px] text-[#4a4a4a]">Filter campaigns by niche, rate, and platform.</p>
+                <h3 className="font-sora font-[600] text-[18px] text-background mb-2">Explore Gigs</h3>
+                <p className="font-geist text-[16px] text-[var(--muted-dark)]">Filter campaigns by niche, rate, and platform.</p>
               </div>
             </div>
             <div className="flex gap-4">
-              <div className="mt-1"><Zap className="w-6 h-6 text-[#131313]" /></div>
+              <div className="mt-1"><Zap className="w-6 h-6 text-background" /></div>
               <div>
-                <h3 className="font-sora font-[600] text-[18px] text-[#131313] mb-2">Execute Fast</h3>
-                <p className="font-geist text-[16px] text-[#4a4a4a]">Submit content proof and trigger smart releases.</p>
+                <h3 className="font-sora font-[600] text-[18px] text-background mb-2">Execute Fast</h3>
+                <p className="font-geist text-[16px] text-[var(--muted-dark)]">Submit content proof and trigger smart releases.</p>
               </div>
             </div>
             <div className="flex gap-4">
-              <div className="mt-1"><Wallet className="w-6 h-6 text-[#131313]" /></div>
+              <div className="mt-1"><Wallet className="w-6 h-6 text-background" /></div>
               <div>
-                <h3 className="font-sora font-[600] text-[18px] text-[#131313] mb-2">Instant Payout</h3>
-                <p className="font-geist text-[16px] text-[#4a4a4a]">Receive XLM or stablecoins directly to your wallet.</p>
+                <h3 className="font-sora font-[600] text-[18px] text-background mb-2">Instant Payout</h3>
+                <p className="font-geist text-[16px] text-[var(--muted-dark)]">Receive XLM or stablecoins directly to your wallet.</p>
               </div>
             </div>
           </div>

--- a/apps/frontend/components/landing/UniversalPayouts.tsx
+++ b/apps/frontend/components/landing/UniversalPayouts.tsx
@@ -1,6 +1,6 @@
 export function UniversalPayouts() {
   return (
-    <section className="py-16 md:py-[100px] px-6 bg-[#181818] border-y border-white/[0.03]">
+    <section className="py-16 md:py-[100px] px-6 bg-surface-container border-y border-outline-variant">
       <div className="max-w-[1280px] mx-auto text-center">
         <h2 className="font-sora font-[600] text-[32px] text-on-surface mb-12">
           Universal Payouts. Local Context.
@@ -8,28 +8,28 @@ export function UniversalPayouts() {
         
         <div className="flex flex-wrap justify-center gap-4 md:gap-6 mb-12">
           {/* USDC */}
-          <div className="bg-[#131313] border border-white/[0.06] rounded-[8px] p-6 flex flex-col items-center justify-center w-[160px] md:w-[240px] h-[160px] md:h-[180px]">
+          <div className="bg-background border border-outline-variant rounded-[8px] p-6 flex flex-col items-center justify-center w-[160px] md:w-[240px] h-[160px] md:h-[180px]">
             <div className="w-[56px] h-[56px] bg-white rounded-[14px] flex items-center justify-center mb-5 shadow-sm">
-              <span className="font-geist font-[800] text-[#131313] text-[15px]">USDC</span>
+              <span className="font-geist font-[800] text-background text-[15px]">USDC</span>
             </div>
             <span className="font-geist font-[700] text-[12px] text-on-surface tracking-wide">Stablecoin</span>
           </div>
           {/* XLM */}
-          <div className="bg-[#131313] border border-white/[0.06] rounded-[8px] p-6 flex flex-col items-center justify-center w-[160px] md:w-[240px] h-[160px] md:h-[180px]">
+          <div className="bg-background border border-outline-variant rounded-[8px] p-6 flex flex-col items-center justify-center w-[160px] md:w-[240px] h-[160px] md:h-[180px]">
             <div className="w-[56px] h-[56px] bg-primary-container rounded-[14px] flex items-center justify-center mb-5 shadow-sm">
-              <span className="font-geist font-[800] text-[#131313] text-[15px]">XLM</span>
+              <span className="font-geist font-[800] text-background text-[15px]">XLM</span>
             </div>
             <span className="font-geist font-[700] text-[12px] text-on-surface tracking-wide">Network Asset</span>
           </div>
           {/* NGN */}
-          <div className="bg-[#131313] border border-white/[0.06] rounded-[8px] p-6 flex flex-col items-center justify-center w-[160px] md:w-[240px] h-[160px] md:h-[180px]">
+          <div className="bg-background border border-outline-variant rounded-[8px] p-6 flex flex-col items-center justify-center w-[160px] md:w-[240px] h-[160px] md:h-[180px]">
             <div className="w-[56px] h-[56px] bg-[#10a151] rounded-[14px] flex items-center justify-center mb-5 shadow-sm">
               <span className="font-geist font-[800] text-white text-[15px]">NGN</span>
             </div>
             <span className="font-geist font-[700] text-[12px] text-on-surface tracking-wide">Nigerian Naira</span>
           </div>
           {/* KES */}
-          <div className="bg-[#131313] border border-white/[0.06] rounded-[8px] p-6 flex flex-col items-center justify-center w-[160px] md:w-[240px] h-[160px] md:h-[180px]">
+          <div className="bg-background border border-outline-variant rounded-[8px] p-6 flex flex-col items-center justify-center w-[160px] md:w-[240px] h-[160px] md:h-[180px]">
             <div className="w-[56px] h-[56px] bg-[#ff0000] rounded-[14px] flex items-center justify-center mb-5 shadow-sm">
               <span className="font-geist font-[800] text-white text-[15px]">KES</span>
             </div>


### PR DESCRIPTION
## Summary

Replace hardcoded hex colors in two landing page sections with Tailwind theme utilities defined in `globals.css`, improving consistency with the rest of the landing page.

**Files changed:**
- `components/landing/BrandsCreators.tsx` — Creators column now uses `bg-white`, `text-background`, and `text-[var(--muted-dark)]` instead of hardcoded hex values
- `components/landing/UniversalPayouts.tsx` — section and cards use `bg-surface-container`, `bg-background`, `border-outline-variant`, and `text-background`

Brand-specific icon colors for NGN (`#10a151`) and KES (`#ff0000`) are preserved as allowed by the issue.

## Context

On the white Creators column, `text-[var(--muted-dark)]` is used for body/label text instead of `text-on-surface-variant`, since the latter is designed for dark surfaces.

## Test plan

- [x] Visual check on `/` — UniversalPayouts section (4 asset cards, borders, brand icon colors)
- [x] Visual check on `/` — BrandsCreators section (dark Brands + white Creators columns)
- [x] No hardcoded hex remains except NGN/KES brand icon colors
- [x] `pnpm --filter @ads-bazaar/frontend build`

Closes #89 for GrantFox