### PR TITLE
feat(explore): add navigation link to trending campaign cards

### DIFF
--- a/apps/frontend/components/explore/trending-campaign-card.tsx
+++ b/apps/frontend/components/explore/trending-campaign-card.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { ArrowUpRight, Briefcase, Plus } from "lucide-react";
 import type { TrendingCampaignItem } from "./explore-data";
 
@@ -9,59 +10,61 @@ export function TrendingCampaignCard({
   const isFeatured = campaign.tag === "featured";
 
   return (
-    <article
-      className={`border border-outline-variant p-5 flex flex-col h-full ${
-        isFeatured
-          ? "bg-primary-container text-on-primary"
-          : "bg-surface-container text-on-surface"
-      }`}
-    >
-      {/* Header: icon box + optional tag badge */}
-      <div className="flex items-start justify-between mb-4">
-        <div
-          className={`size-12 flex items-center justify-center ${campaign.iconBg}`}
-        >
-          <Briefcase className="size-6" />
-        </div>
+    <Link href={`/marketplace/${campaign.id}`} className="block h-full">
+      <article
+        className={`border border-outline-variant p-5 flex flex-col h-full cursor-pointer ${
+          isFeatured
+            ? "bg-primary-container text-on-primary"
+            : "bg-surface-container text-on-surface"
+        }`}
+      >
+        {/* Header: icon box + optional tag badge */}
+        <div className="flex items-start justify-between mb-4">
+          <div
+            className={`size-12 flex items-center justify-center ${campaign.iconBg}`}
+          >
+            <Briefcase className="size-6" />
+          </div>
 
-        {campaign.tag === "hot" && (
-          <span className="rounded border px-2 py-0.5 text-[10px] font-bold tracking-widest border-red-400 text-red-400">
-            HOT
-          </span>
-        )}
-        {campaign.tag === "featured" && (
-          <span className="rounded border px-2 py-0.5 text-[10px] font-bold tracking-widest border-on-primary/30 text-on-primary">
-            FEATURED
-          </span>
-        )}
-      </div>
-
-      {/* Body */}
-      <h3 className="font-sora text-lg font-bold">{campaign.title}</h3>
-      <p className="text-sm leading-relaxed mt-2 line-clamp-2 opacity-80">
-        {campaign.description}
-      </p>
-
-      {/* Footer: budget + action icon */}
-      <div className="flex items-center justify-between mt-auto pt-4">
-        <div>
-          <p className="text-[10px] font-semibold uppercase tracking-[0.05em] opacity-60">
-            BUDGET
-          </p>
-          <p className="font-sora text-lg font-bold">{campaign.budget}</p>
-        </div>
-        <div
-          className={`size-10 border flex items-center justify-center ${
-            isFeatured ? "border-on-primary/30" : "border-outline-variant"
-          }`}
-        >
-          {isFeatured ? (
-            <ArrowUpRight className="size-5" />
-          ) : (
-            <Plus className="size-5" />
+          {campaign.tag === "hot" && (
+            <span className="rounded border px-2 py-0.5 text-[10px] font-bold tracking-widest border-red-400 text-red-400">
+              HOT
+            </span>
+          )}
+          {campaign.tag === "featured" && (
+            <span className="rounded border px-2 py-0.5 text-[10px] font-bold tracking-widest border-on-primary/30 text-on-primary">
+              FEATURED
+            </span>
           )}
         </div>
-      </div>
-    </article>
+
+        {/* Body */}
+        <h3 className="font-sora text-lg font-bold">{campaign.title}</h3>
+        <p className="text-sm leading-relaxed mt-2 line-clamp-2 opacity-80">
+          {campaign.description}
+        </p>
+
+        {/* Footer: budget + action icon */}
+        <div className="flex items-center justify-between mt-auto pt-4">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.05em] opacity-60">
+              BUDGET
+            </p>
+            <p className="font-sora text-lg font-bold">{campaign.budget}</p>
+          </div>
+          <div
+            className={`size-10 border flex items-center justify-center ${
+              isFeatured ? "border-on-primary/30" : "border-outline-variant"
+            }`}
+          >
+            {isFeatured ? (
+              <ArrowUpRight className="size-5" />
+            ) : (
+              <Plus className="size-5" />
+            )}
+          </div>
+        </div>
+      </article>
+    </Link>
   );
 }


### PR DESCRIPTION


### Problem

The trending campaign cards on the Explore page had action icon buttons (`Plus` for regular cards, `ArrowUpRight` for featured cards) that were styled as interactive elements but had no `onClick` handlers. Clicking them did nothing. The cards themselves also had no navigation.

closes #88 

### Changes

**`apps/frontend/components/explore/trending-campaign-card.tsx`**

- Wrapped each card in a Next.js `<Link>` pointing to `/marketplace/${campaign.id}`
- Added `cursor-pointer` to the article element for a clear hover affordance
- No logic changes — layout, styles, and data are untouched

### Acceptance Criteria

- [x] Clicking a trending campaign card navigates to `/marketplace/{id}`
- [x] No non-functional interactive elements remain
- [x] Only the required file was modified
