### PR TITLE
fix: add marketplace empty state

### DIFF
--- a/apps/frontend/components/marketplace/marketplace-grid.tsx
+++ b/apps/frontend/components/marketplace/marketplace-grid.tsx
@@ -1,3 +1,4 @@
+import { Search } from "lucide-react";
 import Link from "next/link";
 import type { MarketplaceCampaign } from "./marketplace-data";
 import { MarketplaceCampaignCard } from "./marketplace-campaign-card";
@@ -9,9 +10,16 @@ type MarketplaceGridProps = {
 export function MarketplaceGrid({ campaigns }: MarketplaceGridProps) {
   if (campaigns.length === 0) {
     return (
-      <div className="border border-outline-variant bg-surface-container py-16 text-center">
-        <p className="text-on-surface-variant text-sm">
-          No campaigns match your search. Try a different keyword.
+      <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+        <Search
+          className="size-10 text-on-surface-variant"
+          aria-hidden="true"
+        />
+        <p className="text-sm font-semibold text-on-surface">
+          No campaigns found
+        </p>
+        <p className="max-w-xs text-sm text-on-surface-variant">
+          Try adjusting your search to find what you are looking for.
         </p>
       </div>
     );


### PR DESCRIPTION
## Summary
- add a centered empty state to the marketplace grid when no campaigns match the current search
- include the requested search icon, title, and helper copy using existing surface text tokens
- keep the populated campaign grid rendering unchanged

Closes #120

## Validation
- npx pnpm@10.18.3 --filter @ads-bazaar/frontend build

Note: the existing frontend lint script currently runs `next lint`, which fails under this Next.js version with an invalid project directory error before linting files.