### PR TITLE
fix: persist campaign wizard drafts across refresh

### DIFF
--- a/apps/frontend/app/dashboard/business/payouts/page.tsx
+++ b/apps/frontend/app/dashboard/business/payouts/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next";
 import { DashboardHeader } from '@/components/dashboard/shared/dashboard-header';
-import type { Metadata } from "next";
 import { PayoutsHeader } from '@/components/dashboard/business/payouts-header';
-
-export const metadata: Metadata = {
-  title: "Payouts",
-};
 import { EscrowStatCard } from '@/components/dashboard/business/escrow-stat-card';
 import { WalletAssetsPanel } from '@/components/dashboard/business/wallet-assets-panel';
 import { SorobanContractsSection } from '@/components/dashboard/business/soroban-contracts-section';
@@ -17,6 +12,10 @@ import {
   sorobanContracts,
   transactions,
 } from '@/components/dashboard/business/payouts-data';
+
+export const metadata: Metadata = {
+  title: "Payouts",
+};
 
 export default function BusinessPayoutsPage() {
   return (

--- a/apps/frontend/app/dashboard/business/settings/page.tsx
+++ b/apps/frontend/app/dashboard/business/settings/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { DashboardHeader } from "@/components/dashboard/shared/dashboard-header";
-import type { Metadata } from "next";
 import { ProfileSection } from "@/components/dashboard/shared/profile-section";
 
 export const metadata: Metadata = {

--- a/apps/frontend/app/dashboard/creator/analytics/page.tsx
+++ b/apps/frontend/app/dashboard/creator/analytics/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { DashboardHeader } from "@/components/dashboard/shared/dashboard-header";
-import type { Metadata } from "next";
 import { analyticStats, growthSeries, ageGroups, topLocations, channels, topCampaigns } from "@/components/dashboard/creator/creator-analytics-data";
 
 export const metadata: Metadata = {

--- a/apps/frontend/app/dashboard/creator/inventory/page.tsx
+++ b/apps/frontend/app/dashboard/creator/inventory/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { DashboardHeader } from "@/components/dashboard/shared/dashboard-header";
-import type { Metadata } from "next";
 import { ConnectedChannels } from "@/components/dashboard/creator/connected-channels";
 
 export const metadata: Metadata = {

--- a/apps/frontend/app/dashboard/creator/settings/page.tsx
+++ b/apps/frontend/app/dashboard/creator/settings/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { DashboardHeader } from "@/components/dashboard/shared/dashboard-header";
-import type { Metadata } from "next";
 import { ProfileSection } from "@/components/dashboard/shared/profile-section";
 
 export const metadata: Metadata = {

--- a/apps/frontend/components/dashboard/business/campaign-wizard-modal.tsx
+++ b/apps/frontend/components/dashboard/business/campaign-wizard-modal.tsx
@@ -127,12 +127,12 @@ export function CampaignWizardModal() {
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
   const mainRef = useRef<HTMLElement>(null);
 
-  // Restore draft from sessionStorage when modal opens
+  // Restore draft from localStorage when modal opens
   useEffect(() => {
     if (!isOpen) return;
 
     try {
-      const saved = sessionStorage.getItem(DRAFT_KEY);
+      const saved = localStorage.getItem(DRAFT_KEY);
       if (saved) {
         const parsed = JSON.parse(saved) as WizardState;
         setState(parsed);
@@ -148,7 +148,7 @@ export function CampaignWizardModal() {
     if (!hydrated || !isOpen) return;
 
     try {
-      sessionStorage.setItem(DRAFT_KEY, JSON.stringify(state));
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(state));
     } catch {
       // ignore
     }
@@ -228,7 +228,7 @@ export function CampaignWizardModal() {
   }
 
   function handleDiscard() {
-    sessionStorage.removeItem(DRAFT_KEY);
+    localStorage.removeItem(DRAFT_KEY);
     setState(initialState);
     handleClose();
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,3 @@
 packages:
   - "apps/*"
   - "packages/*"
-allowBuilds:
-  sharp: true
-  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "apps/*"
   - "packages/*"
+allowBuilds:
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary
- switch campaign wizard draft persistence from sessionStorage to localStorage
- keep discard flow clearing the saved draft
- fix unrelated duplicate Metadata imports blocking frontend build

## Test
- corepack pnpm --filter @ads-bazaar/frontend build

Closes #129