### PR TITLE
fix: add Browse more campaigns navigation link to marketplace success…

### DIFF
--- a/apps/frontend/components/marketplace/application-form.tsx
+++ b/apps/frontend/components/marketplace/application-form.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { ChevronDown, CircleCheck } from "lucide-react";
 import { campaignDetailMock } from "./campaign-detail-data";
+import Link from "next/link";
 
 const PITCH_MIN_LENGTH = 20;
 
@@ -87,6 +88,14 @@ export function ApplicationForm({
             Your application is in. The brand will review your pitch and reach
             out if it&apos;s a match.
           </p>
+          <div className="flex flex-col gap-2 mt-4">
+            <Link
+              href="/marketplace"
+              className="text-sm font-semibold text-primary-container hover:underline text-center"
+            >
+              ← Browse more campaigns
+            </Link>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## What does this PR do?
Adds a "Browse more campaigns" navigation link to the application success state in the marketplace campaign detail page.

## Why?
Closes #127 — after submitting an application on `/marketplace/[id]`, the success card had no navigation. Users were stuck staring at the success message unless they used the browser back button or the Navbar.

## Change

### `apps/frontend/components/marketplace/application-form.tsx`
- Added `import Link from "next/link"`
- Added a "← Browse more campaigns" link below the success message pointing to `/marketplace`
- Uses existing `text-primary-container` token and `hover:underline` styling consistent with the rest of the codebase

**Only 1 file changed** as required.

## Acceptance criteria
- [x] Success state includes a "Browse more campaigns" link back to `/marketplace`
- [x] Link uses landing page tokens (`text-primary-container`)
- [x] User can navigate away after submission without browser back button
- [x] Only 1 file changed
- [x] `tsc --noEmit` clean
- [x] Closes #127