### PR TITLE
Use design tokens for notification badge colors

### DIFF
--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -26,6 +26,8 @@
   --db-on-surface-variant: #c5c9ae;
   --db-primary-container: #c8f232;
   --db-on-primary: #293500;
+  --db-danger: #ffb4ab;
+  --db-on-danger: #690005;
   --db-outline-variant: #444934;
 
   --font-geist: var(--font-geist-sans);

--- a/apps/frontend/components/notifications/notification-bell.tsx
+++ b/apps/frontend/components/notifications/notification-bell.tsx
@@ -9,6 +9,7 @@ export type NotificationBellVariant = "landing" | "dashboard";
 type VariantClasses = {
   button: string;
   buttonHover: string;
+  badgeBg: string;
   badgeText: string;
   panel: string;
   panelHeaderBorder: string;
@@ -31,7 +32,8 @@ type VariantClasses = {
 const LANDING_VARIANT: VariantClasses = {
   button: "relative text-on-surface-variant",
   buttonHover: "hover:text-on-surface",
-  badgeText: "text-[#293500]",
+  badgeBg: "bg-[var(--db-danger)]",
+  badgeText: "text-[var(--db-on-danger)]",
   panel: "bg-surface-container border-outline-variant",
   panelHeaderBorder: "border-outline-variant",
   panelHeaderTitle: "text-on-surface",
@@ -55,7 +57,8 @@ const DASHBOARD_VARIANT: VariantClasses = {
     "relative flex size-11 items-center justify-center rounded text-[var(--dash-muted)]",
   buttonHover:
     "hover:text-[var(--dash-heading)] hover:bg-[var(--dash-surface)]",
-  badgeText: "text-[var(--dash-on-accent-strong)]",
+  badgeBg: "bg-[var(--dash-danger)]",
+  badgeText: "text-[var(--dash-on-danger)]",
   panel: "bg-[var(--dash-surface)] border-[var(--dash-border)]",
   panelHeaderBorder: "border-[var(--dash-border)]",
   panelHeaderTitle: "text-[var(--dash-heading)]",
@@ -184,7 +187,7 @@ export function NotificationBell({ variant, className }: NotificationBellProps) 
         {unreadCount > 0 && (
           <span
             aria-hidden="true"
-            className={`absolute right-1 top-1 inline-flex min-w-[18px] items-center justify-center rounded-full bg-[var(--db-danger,#ff5470)] px-1 text-[10px] font-bold leading-[14px] ${v.badgeText}`}
+            className={`absolute right-1 top-1 inline-flex min-w-[18px] items-center justify-center rounded-full px-1 text-[10px] font-bold leading-[14px] ${v.badgeBg} ${v.badgeText}`}
           >
             {unreadCount > 9 ? "9+" : unreadCount}
           </span>


### PR DESCRIPTION
## Summary
- replace the notification badge's hardcoded inline hex/fallback colors with variant-specific design tokens
- add landing-page danger/on-danger tokens alongside the existing landing token set
- make the dashboard notification badge use the existing `--dash-danger` and `--dash-on-danger` token pair

This finishes the token-system acceptance item for the notification bell implementation currently on `main`.

Closes #58.

## Validation
- `git diff --check` passes
- `apps/frontend/node_modules/.bin/tsc.CMD --noEmit` runs, but the repo currently fails on pre-existing unrelated errors:
  - `app/dashboard/creator/campaigns/[id]/page.tsx`: missing `@/components/dashboard/creator/dashboard-header`
  - `app/dashboard/creator/campaigns/page.tsx`: `CampaignListRow` receives unsupported `onClick`
- `next lint` is not available as a Next 16 subcommand in this repo; direct ESLint currently fails during config loading with an existing circular config serialization error before reaching changed files